### PR TITLE
Fix error message spacing in dispatch

### DIFF
--- a/R/dispatch.R
+++ b/R/dispatch.R
@@ -28,7 +28,7 @@ forward_step <- function(type, desc, handle) {
 forward_step.default <- function(type, desc, handle) {
   # TODO: Replace stop() with lna:::abort_lna(..., .subclass="lna_error_no_method")
   #       when error handling (M0-12) is implemented.
-  stop(paste("No forward_step method implemented for transform type: ", type),
+  stop(paste("No forward_step method implemented for transform type:", type),
        call. = FALSE)
 }
 
@@ -55,6 +55,6 @@ invert_step <- function(type, desc, handle) {
 invert_step.default <- function(type, desc, handle) {
   # TODO: Replace stop() with lna:::abort_lna(..., .subclass="lna_error_no_method")
   #       when error handling (M0-12) is implemented.
-  stop(paste("No invert_step method implemented for transform type: ", type),
+  stop(paste("No invert_step method implemented for transform type:", type),
        call. = FALSE)
 } 


### PR DESCRIPTION
## Summary
- clean up spacing in `forward_step.default()` and `invert_step.default()` messages

## Testing
- `R -q -e 'print("hi")'` *(fails: `bash: R: command not found`)*