### PR TITLE
Implement M0-9 core_read

### DIFF
--- a/R/core_read.R
+++ b/R/core_read.R
@@ -1,0 +1,39 @@
+#' Core LNA Read Routine
+#'
+#' @description Opens an LNA HDF5 file, discovers available transform
+#'   descriptors and runs the inverse transform chain. This is a
+#'   minimal skeleton used during early development.
+#'
+#' @param file Path to an LNA file on disk.
+#' @param allow_plugins Placeholder argument for plugin policy.
+#' @param validate Logical flag indicating if validation should be
+#'   performed. Currently ignored.
+#'
+#' @return A `DataHandle` object representing the loaded data.
+#' @import hdf5r
+#' @keywords internal
+core_read <- function(file, allow_plugins = c("warn", "off", "on"), validate = FALSE) {
+  allow_plugins <- match.arg(allow_plugins)
+  h5 <- H5File$new(file, mode = "r")
+  on.exit({
+    if (inherits(h5, "H5File") && h5$is_valid()) h5$close_all()
+  })
+
+  handle <- DataHandle$new(h5 = h5)
+  tf_group <- h5[["transforms"]]
+
+  transforms <- discover_transforms(tf_group)
+
+  # TODO: make use of allow_plugins and validate
+
+  if (nrow(transforms) > 0) {
+    for (i in rev(seq_len(nrow(transforms)))) {
+      name <- transforms$name[[i]]
+      type <- transforms$type[[i]]
+      desc <- read_json_descriptor(tf_group, name)
+      handle <- invert_step(type, desc, handle)
+    }
+  }
+
+  return(handle)
+}

--- a/tests/testthat/test-core_read.R
+++ b/tests/testthat/test-core_read.R
@@ -1,0 +1,46 @@
+library(testthat)
+library(hdf5r)
+library(withr)
+
+# Ensure core_read and helpers are loaded
+# source("../R/core_read.R")
+
+# Helper to create empty transforms group
+create_empty_lna <- function(path) {
+  h5 <- H5File$new(path, mode = "w")
+  h5$create_group("transforms")
+  h5$close_all()
+}
+
+# Helper to create lna with one dummy descriptor
+create_dummy_lna <- function(path) {
+  h5 <- H5File$new(path, mode = "w")
+  tf <- h5$create_group("transforms")
+  write_json_descriptor(tf, "00_dummy.json", list(type = "dummy"))
+  h5$close_all()
+}
+
+test_that("core_read handles empty /transforms group", {
+  tmp <- local_tempfile(fileext = ".h5")
+  create_empty_lna(tmp)
+
+  handle <- core_read(tmp)
+  expect_true(inherits(handle, "DataHandle"))
+  expect_false(handle$h5$is_valid())
+})
+
+test_that("core_read closes file if invert_step errors", {
+  tmp <- local_tempfile(fileext = ".h5")
+  create_dummy_lna(tmp)
+
+  captured_h5 <- NULL
+  with_mocked_bindings(
+    invert_step.default = function(type, desc, handle) {
+      captured_h5 <<- handle$h5
+      stop("mock error")
+    },
+    expect_error(core_read(tmp), "mock error")
+  )
+  expect_true(inherits(captured_h5, "H5File"))
+  expect_false(captured_h5$is_valid())
+})


### PR DESCRIPTION
## Summary
- implement core_read skeleton
- add tests for core_read behavior

## Testing
- `devtools::test()` *(fails: command not found)*