### PR TITLE
Implement core write skeleton

### DIFF
--- a/R/core_write.R
+++ b/R/core_write.R
@@ -1,0 +1,54 @@
+#' Core Write Pipeline (Skeleton)
+#'
+#' @description Internal function orchestrating the forward transform pass.
+#'   This version implements the bare structure used for early milestones.
+#'
+#' @param x An input object to be written.
+#' @param transforms Character vector of transform types (forward order).
+#' @param transform_params Named list of user supplied parameters for transforms.
+#'
+#' @return A list with `handle` and `plan` objects.
+#' @keywords internal
+core_write <- function(x, transforms, transform_params = list()) {
+  stopifnot(is.character(transforms))
+  stopifnot(is.list(transform_params))
+
+  # --- Stub: derive initial mask/header from `x` ---
+  mask <- NULL
+  header <- list()
+
+  # --- Create plan and initial handle ---
+  plan <- Plan$new()
+  handle <- DataHandle$new(
+    initial_stash = list(input = x),
+    initial_meta = list(mask = mask, header = header),
+    plan = plan
+  )
+
+  # --- Stub: merge parameters with defaults ---
+  pkg_opts <- lna_options()
+  merged_params <- list()
+  for (type in transforms) {
+    defaults <- default_params(type)
+    pkg_default <- pkg_opts[[type]]
+    user <- transform_params[[type]]
+
+    params <- defaults
+    if (is.list(pkg_default)) {
+      params <- utils::modifyList(params, pkg_default)
+    }
+    if (is.list(user)) {
+      params <- utils::modifyList(params, user)
+    }
+    merged_params[[type]] <- params
+  }
+
+  # --- Loop through transforms calling forward_step ---
+  for (type in transforms) {
+    desc <- list(type = type, params = merged_params[[type]])
+    cls <- structure(type, class = c(type, "character"))
+    handle <- forward_step(cls, desc, handle)
+  }
+
+  list(handle = handle, plan = plan)
+}

--- a/R/options.R
+++ b/R/options.R
@@ -1,0 +1,24 @@
+#' Package Options for LNA
+#'
+#' Minimal stub implementation storing options in a package environment.
+#'
+#' @param ... Named options to set, or names of options to retrieve.
+#' @return A list of current options or requested values.
+#' @keywords internal
+lna_options <- function(...) {
+  .lna_opts <- get(".lna_opts", envir = lna_options_env)
+  args <- list(...)
+  if (length(args) == 0) {
+    return(as.list(.lna_opts))
+  }
+  if (is.null(names(args))) {
+    return(mget(unlist(args), envir = .lna_opts, ifnotfound = list(NULL)))
+  }
+  for (nm in names(args)) {
+    assign(nm, args[[nm]], envir = .lna_opts)
+  }
+  invisible(as.list(.lna_opts))
+}
+
+lna_options_env <- new.env(parent = emptyenv())
+assign(".lna_opts", new.env(parent = emptyenv()), envir = lna_options_env)

--- a/R/utils_defaults.R
+++ b/R/utils_defaults.R
@@ -1,0 +1,17 @@
+#' Default Parameter Retrieval (Stub)
+#'
+#' Provides a cached stub returning an empty list for any transform type.
+#'
+#' @param type Character transform type.
+#' @return A list of default parameters (currently empty).
+#' @keywords internal
+.default_param_cache <- new.env(parent = emptyenv())
+
+default_params <- function(type) {
+  stopifnot(is.character(type), length(type) == 1)
+  if (exists(type, envir = .default_param_cache, inherits = FALSE)) {
+    return(.default_param_cache[[type]])
+  }
+  .default_param_cache[[type]] <- list()
+  .default_param_cache[[type]]
+}

--- a/tests/testthat/test-core_write.R
+++ b/tests/testthat/test-core_write.R
@@ -1,0 +1,31 @@
+library(testthat)
+
+#' Mock forward_step methods that simply add descriptors to the plan
+forward_step.tA <- function(type, desc, handle) {
+  handle$plan$add_descriptor(handle$plan$get_next_filename(type), desc)
+  handle
+}
+
+forward_step.tB <- function(type, desc, handle) {
+  handle$plan$add_descriptor(handle$plan$get_next_filename(type), desc)
+  handle
+}
+
+assign("forward_step.tA", forward_step.tA, envir = .GlobalEnv)
+assign("forward_step.tB", forward_step.tB, envir = .GlobalEnv)
+withr::defer({
+  rm(forward_step.tA, envir = .GlobalEnv)
+  rm(forward_step.tB, envir = .GlobalEnv)
+})
+
+
+# Core test
+
+test_that("core_write executes forward loop and merges params", {
+  result <- core_write(x = 1, transforms = c("tA", "tB"), transform_params = list(tB = list(foo = "bar")))
+  plan <- result$plan
+  expect_equal(plan$next_index, 2L)
+  expect_equal(length(plan$descriptors), 2)
+  expect_equal(plan$descriptors[[1]]$type, "tA")
+  expect_equal(plan$descriptors[[2]]$params, list(foo = "bar"))
+})


### PR DESCRIPTION
## Summary
- implement `core_write` for forward transform orchestration
- add stub helpers for options and default parameters
- provide unit test for the core write loop

## Testing
- `R CMD check` *(fails: R not available)*