### PR TITLE
Implement M0-7 generics

### DIFF
--- a/R/dispatch.R
+++ b/R/dispatch.R
@@ -26,14 +26,12 @@ forward_step <- function(type, desc, handle) {
 #' @export
 #' @keywords internal
 forward_step.default <- function(type, desc, handle) {
-  # TODO: Replace stop() with lna:::abort_lna(..., .subclass="lna_error_no_method")
-  #       when error handling (M0-12) is implemented.
-  stop(
+  abort_lna(
     sprintf(
       "No forward_step method implemented for transform type: %s",
       type
     ),
-    call. = FALSE
+    .subclass = "lna_error_no_method"
   )
 }
 
@@ -58,13 +56,11 @@ invert_step <- function(type, desc, handle) {
 #' @export
 #' @keywords internal
 invert_step.default <- function(type, desc, handle) {
-  # TODO: Replace stop() with lna:::abort_lna(..., .subclass="lna_error_no_method")
-  #       when error handling (M0-12) is implemented.
-  stop(
+  abort_lna(
     sprintf(
       "No invert_step method implemented for transform type: %s",
       type
     ),
-    call. = FALSE
+    .subclass = "lna_error_no_method"
   )
-} 
+}

--- a/R/utils_error.R
+++ b/R/utils_error.R
@@ -1,0 +1,10 @@
+#' Error Handling Utilities
+#'
+#' @description
+#' Provides helper wrappers around `rlang::abort` for LNA specific
+#' error classes.
+#' @keywords internal
+#' @import rlang
+abort_lna <- function(message, ..., .subclass = NULL) {
+  rlang::abort(message = message, ..., .subclass = .subclass)
+}

--- a/tests/testthat/test-dispatch.R
+++ b/tests/testthat/test-dispatch.R
@@ -16,8 +16,8 @@ test_that("forward_step generic dispatches to default and errors", {
   # Check that calling with an undefined type dispatches to default and errors
   expect_error(
     forward_step(dummy_type, dummy_desc, dummy_handle),
-    regexp = paste("No forward_step method implemented for transform type:", dummy_type)
-    # TODO: Update error class check when lna_error_no_method is defined
+    regexp = paste("No forward_step method implemented for transform type:", dummy_type),
+    class = "lna_error_no_method"
   )
 })
 
@@ -32,7 +32,7 @@ test_that("invert_step generic dispatches to default and errors", {
   # Check that calling with an undefined type dispatches to default and errors
   expect_error(
     invert_step(dummy_type, dummy_desc, dummy_handle),
-    regexp = paste("No invert_step method implemented for transform type:", dummy_type)
-    # TODO: Update error class check when lna_error_no_method is defined
+    regexp = paste("No invert_step method implemented for transform type:", dummy_type),
+    class = "lna_error_no_method"
   )
 }) 


### PR DESCRIPTION
## Summary
- add `abort_lna` helper for error creation
- use `abort_lna` in `forward_step.default` and `invert_step.default`
- update unit tests for new error class

## Testing
- `Rscript -e 'print("hello")'` *(fails: command not found)*