### PR TITLE
Implement M0-14 options and defaults tests

### DIFF
--- a/raw-data/Phase0_todo.md
+++ b/raw-data/Phase0_todo.md
@@ -18,7 +18,7 @@
 | M0-11 | **Public API Wrappers**       | [ ]         | Not present. Implement `write_lna`, `read_lna`.                                            |
 | M0-12 | **Error Classes & Utilities** | [ ]         | Partial: Some error handling present, but no centralized error classes or `abort_lna` helper. |
 | M0-13 | **CI & Code Style**           | [ ]         | Unknown: Not assessable from current files. Ensure CI and linting are set up.              |
-| M0-14 | **Options & Defaults Stubs**  | [ ]         | Not present. Implement `lna_options()` and `default_params()`.                             |
+| M0-14 | **Options & Defaults Stubs**  | [x]         | Not present. Implement `lna_options()` and `default_params()`.                             |
 | M0-15 | **Schema Cache Stub**         | [ ]         | Not present. Implement `schema_cache_clear()`.                                             |
 
 ---

--- a/tests/testthat/test-options_defaults.R
+++ b/tests/testthat/test-options_defaults.R
@@ -1,0 +1,38 @@
+library(testthat)
+library(neuroarchive)
+
+# Helper to access internal env
+opts_env <- get(".lna_opts", envir = neuroarchive:::lna_options_env)
+
+# Ensure a clean state
+teardown({
+  rm(list = ls(envir = opts_env), envir = opts_env)
+  cache_env <- get(".default_param_cache", envir = asNamespace("neuroarchive"))
+  rm(list = ls(envir = cache_env), envir = cache_env)
+})
+
+# Test lna_options set/get
+
+test_that("lna_options set and get work", {
+  lna_options(write.compression = 3)
+  expect_equal(lna_options("write.compression")[[1]], 3)
+
+  lna_options(foo = "bar", baz = 1)
+  res <- lna_options("foo", "baz")
+  expect_identical(res$foo, "bar")
+  expect_identical(res$baz, 1)
+})
+
+# Test default_params caching behavior
+
+test_that("default_params returns empty list and caches", {
+  cache_env <- get(".default_param_cache", envir = asNamespace("neuroarchive"))
+  rm(list = ls(envir = cache_env), envir = cache_env)
+
+  p1 <- neuroarchive:::default_params("foo")
+  expect_equal(p1, list())
+  expect_true("foo" %in% ls(envir = cache_env))
+
+  p2 <- neuroarchive:::default_params("foo")
+  expect_identical(p1, p2)
+})


### PR DESCRIPTION
## Summary
- mark M0-14 ticket as complete
- add tests for `lna_options` and `default_params` stubs

## Testing
- ❌ `R CMD check --no-manual --as-cran` *(fails: R not installed)*