### PR TITLE
Implement payload writing logic

### DIFF
--- a/tests/testthat/test-materialise_plan.R
+++ b/tests/testthat/test-materialise_plan.R
@@ -2,13 +2,14 @@ library(testthat)
 library(hdf5r)
 library(withr)
 
-# Test materialise_plan stub
+# Test materialise_plan basic functionality
 
 test_that("materialise_plan creates structure and updates plan", {
   tmp <- local_tempfile(fileext = ".h5")
   h5 <- H5File$new(tmp, mode = "w")
   plan <- Plan$new()
   plan$add_descriptor("00_dummy.json", list(type = "dummy"))
+  plan$add_payload("payload", matrix(1:4, nrow = 2))
   plan$add_dataset_def("/scans/run-01/data", "data", "dummy", "run-01", 0L, "{}", "payload", "eager")
 
   materialise_plan(h5, plan)
@@ -26,6 +27,9 @@ test_that("materialise_plan creates structure and updates plan", {
   expect_identical(desc, list(type = "dummy"))
 
   expect_equal(plan$datasets$write_mode_effective, "eager")
+  expect_true(is.null(plan$payloads$payload))
+  expect_true(h5$exists("scans/run-01/data"))
+  expect_equal(h5[["scans/run-01/data"]]$read(), matrix(1:4, nrow = 2))
   expect_true(h5$is_valid())
   h5$close_all()
 })


### PR DESCRIPTION
## Summary
- add dataset payload writing with retry support in `materialise_plan`
- verify payload datasets written and cleared in tests

## Testing
- `R` tests *(fails: command not found)*