### PR TITLE
Implement transform_params merging

### DIFF
--- a/R/core_write.R
+++ b/R/core_write.R
@@ -25,23 +25,8 @@ core_write <- function(x, transforms, transform_params = list()) {
     plan = plan
   )
 
-  # --- Stub: merge parameters with defaults ---
-  pkg_opts <- lna_options()
-  merged_params <- list()
-  for (type in transforms) {
-    defaults <- default_params(type)
-    pkg_default <- pkg_opts[[type]]
-    user <- transform_params[[type]]
-
-    params <- defaults
-    if (is.list(pkg_default)) {
-      params <- utils::modifyList(params, pkg_default)
-    }
-    if (is.list(user)) {
-      params <- utils::modifyList(params, user)
-    }
-    merged_params[[type]] <- params
-  }
+  # --- Resolve parameters with defaults and package options ---
+  merged_params <- resolve_transform_params(transforms, transform_params)
 
   # --- Loop through transforms calling forward_step ---
   for (type in transforms) {

--- a/R/utils_defaults.R
+++ b/R/utils_defaults.R
@@ -15,3 +15,58 @@ default_params <- function(type) {
   .default_param_cache[[type]] <- list()
   .default_param_cache[[type]]
 }
+
+#' Resolve Transform Parameters
+#'
+#' Merges transform parameters from schema defaults, package options, and
+#' user supplied values (in that order). Performs a deep merge using
+#' `utils::modifyList` with left-to-right precedence.
+#'
+#' @param transforms Character vector of transform types.
+#' @param transform_params Named list of user-supplied parameters.
+#' @return Named list of merged parameter lists.
+#' @keywords internal
+resolve_transform_params <- function(transforms, transform_params = list()) {
+  stopifnot(is.character(transforms))
+  stopifnot(is.list(transform_params))
+
+  if (length(transform_params) > 0) {
+    if (is.null(names(transform_params)) || any(names(transform_params) == "")) {
+      abort_lna(
+        "transform_params must be a named list",
+        .subclass = "lna_error_validation"
+      )
+    }
+
+    unknown <- setdiff(names(transform_params), transforms)
+    if (length(unknown) > 0) {
+      abort_lna(
+        paste0(
+          "Unknown transform(s) in transform_params: ",
+          paste(unknown, collapse = ", ")
+        ),
+        .subclass = "lna_error_validation"
+      )
+    }
+  }
+
+  pkg_opts <- lna_options()
+  merged <- setNames(vector("list", length(transforms)), transforms)
+
+  for (type in transforms) {
+    defaults <- default_params(type)
+    pkg_default <- pkg_opts[[type]]
+    user <- transform_params[[type]]
+
+    params <- defaults
+    if (is.list(pkg_default)) {
+      params <- utils::modifyList(params, pkg_default, keep.null = TRUE)
+    }
+    if (is.list(user)) {
+      params <- utils::modifyList(params, user, keep.null = TRUE)
+    }
+    merged[[type]] <- params
+  }
+
+  merged
+}

--- a/tests/testthat/test-core_write.R
+++ b/tests/testthat/test-core_write.R
@@ -29,3 +29,33 @@ test_that("core_write executes forward loop and merges params", {
   expect_equal(plan$descriptors[[1]]$type, "tA")
   expect_equal(plan$descriptors[[2]]$params, list(foo = "bar"))
 })
+
+test_that("transform_params merging honors precedence and deep merge", {
+  opts_env <- get(".lna_opts", envir = neuroarchive:::lna_options_env)
+  rm(list = ls(envir = opts_env), envir = opts_env)
+  lna_options(tB = list(a = 10, nested = list(x = 1)))
+
+  with_mocked_bindings(
+    default_params = function(type) {
+      list(a = 1, b = 2, nested = list(x = 0, y = 0))
+    }, {
+      res <- core_write(
+        x = 1,
+        transforms = c("tB"),
+        transform_params = list(tB = list(b = 20, nested = list(y = 5)))
+      )
+    }
+  )
+
+  expect_equal(
+    res$plan$descriptors[[1]]$params,
+    list(a = 10, b = 20, nested = list(x = 1, y = 5))
+  )
+})
+
+test_that("unknown transform names in transform_params error", {
+  expect_error(
+    core_write(x = 1, transforms = c("tA"), transform_params = list(tB = list())),
+    class = "lna_error_validation"
+  )
+})


### PR DESCRIPTION
## Summary
- implement `resolve_transform_params` helper and use in `core_write`
- validate `transform_params` names and merge defaults, options and user values
- add unit tests for merging precedence and deep merge

## Testing
- `R` command not found; cannot run package tests in this environment