### PR TITLE
Implement M1-3 checksum logic

### DIFF
--- a/tests/testthat/test-materialise_checksum.R
+++ b/tests/testthat/test-materialise_checksum.R
@@ -1,0 +1,25 @@
+library(testthat)
+library(hdf5r)
+library(withr)
+library(digest)
+
+# Test checksum writing
+
+test_that("materialise_plan writes sha256 checksum attribute", {
+  tmp <- local_tempfile(fileext = ".h5")
+  h5 <- H5File$new(tmp, mode = "w")
+  plan <- Plan$new()
+  plan$add_descriptor("00_dummy.json", list(type = "dummy"))
+  plan$add_payload("payload", matrix(1:4, nrow = 2))
+  plan$add_dataset_def("/scans/run-01/data", "data", "dummy", "run-01", 0L, "{}", "payload", "eager")
+
+  materialise_plan(h5, plan, checksum = "sha256")
+
+  expect_false(h5$is_valid())
+  h5r <- H5File$new(tmp, mode = "r")
+  root <- h5r[["/"]]
+  expect_true(h5_attr_exists(root, "lna_checksum"))
+  expected <- digest(file = tmp, algo = "sha256")
+  expect_identical(h5_attr_read(root, "lna_checksum"), expected)
+  h5r$close_all()
+})


### PR DESCRIPTION
## Summary
- extend `materialise_plan` with checksum support
- record SHA256 digests in `lna_checksum` root attribute when requested
- add regression test for checksum handling

## Testing
- `R -q -e "testthat::test_dir('tests/testthat')"` *(fails: `bash: R: command not found`)*