### PR TITLE
Implement run naming in core_write

### DIFF
--- a/R/core_write.R
+++ b/R/core_write.R
@@ -17,12 +17,24 @@ core_write <- function(x, transforms, transform_params = list()) {
   mask <- NULL
   header <- list()
 
+  # --- Determine run identifiers ---
+  if (is.list(x)) {
+    if (is.null(names(x)) || any(names(x) == "")) {
+      names(x) <- sprintf("run-%02d", seq_along(x))
+    }
+    run_ids <- names(x)
+  } else {
+    run_ids <- "run-01"
+  }
+
   # --- Create plan and initial handle ---
   plan <- Plan$new()
   handle <- DataHandle$new(
     initial_stash = list(input = x),
     initial_meta = list(mask = mask, header = header),
-    plan = plan
+    plan = plan,
+    run_ids = run_ids,
+    current_run_id = run_ids[1]
   )
 
   # --- Resolve parameters with defaults and package options ---

--- a/R/handle.R
+++ b/R/handle.R
@@ -18,6 +18,10 @@ DataHandle <- R6::R6Class("DataHandle",
     h5 = NULL,
     #' @field subset A list specifying subsetting parameters (e.g., ROI, time indices).
     subset = NULL,
+    #' @field run_ids Character vector of run identifiers for multi-run data.
+    run_ids = NULL,
+    #' @field current_run_id The run identifier currently being processed.
+    current_run_id = NULL,
 
     #' @description
     #' Initialize a new DataHandle object.
@@ -26,7 +30,9 @@ DataHandle <- R6::R6Class("DataHandle",
     #' @param plan A Plan object (optional, for writing).
     #' @param h5 An H5File object (optional, for reading/writing).
     #' @param subset A list specifying subsetting (optional, for reading).
-    initialize = function(initial_stash = list(), initial_meta = list(), plan = NULL, h5 = NULL, subset = list()) {
+    initialize = function(initial_stash = list(), initial_meta = list(), plan = NULL,
+                          h5 = NULL, subset = list(), run_ids = character(),
+                          current_run_id = NULL) {
       # Basic input validation
       stopifnot(is.list(initial_stash))
       stopifnot(is.list(initial_meta))
@@ -40,11 +46,18 @@ DataHandle <- R6::R6Class("DataHandle",
         stop("'h5' must be an H5File object from hdf5r or NULL")
       }
 
+      stopifnot(is.character(run_ids))
+      if (!is.null(current_run_id)) {
+        stopifnot(is.character(current_run_id), length(current_run_id) == 1)
+      }
+
       self$stash <- initial_stash
       self$meta <- initial_meta
       self$plan <- plan
       self$h5 <- h5
       self$subset <- subset
+      self$run_ids <- run_ids
+      self$current_run_id <- current_run_id
     },
 
     #' @description

--- a/tests/testthat/test-core_write.R
+++ b/tests/testthat/test-core_write.R
@@ -59,3 +59,22 @@ test_that("unknown transform names in transform_params error", {
     class = "lna_error_validation"
   )
 })
+
+test_that("unnamed list input generates run names accessible to forward_step", {
+  captured <- list()
+  forward_step.runTest <- function(type, desc, handle) {
+    captured$run_ids <<- handle$run_ids
+    captured$current_run <<- handle$current_run_id
+    captured$names <<- names(handle$stash$input)
+    handle
+  }
+  assign("forward_step.runTest", forward_step.runTest, envir = .GlobalEnv)
+  withr::defer(rm(forward_step.runTest, envir = .GlobalEnv))
+
+  res <- core_write(x = list(matrix(1), matrix(2)), transforms = "runTest")
+
+  expect_equal(captured$run_ids, c("run-01", "run-02"))
+  expect_equal(captured$names, c("run-01", "run-02"))
+  expect_equal(res$handle$run_ids, c("run-01", "run-02"))
+  expect_equal(res$handle$current_run_id, "run-01")
+})

--- a/tests/testthat/test-handle.R
+++ b/tests/testthat/test-handle.R
@@ -28,6 +28,8 @@ test_that("DataHandle initialization works correctly", {
   expect_null(h_default$h5)
   expect_true(is.list(h_default$subset))
   expect_equal(length(h_default$subset), 0)
+  expect_equal(h_default$run_ids, character(0))
+  expect_null(h_default$current_run_id)
 
   # Initialization with values
   init_stash <- list(a = 1, b = "hello")
@@ -39,13 +41,17 @@ test_that("DataHandle initialization works correctly", {
     initial_meta = init_meta,
     plan = mock_plan,
     h5 = mock_h5,
-    subset = init_subset
+    subset = init_subset,
+    run_ids = c("run-01", "run-02"),
+    current_run_id = "run-01"
   )
   expect_identical(h_init$stash, init_stash)
   expect_identical(h_init$meta, init_meta)
   expect_identical(h_init$plan, mock_plan)
   expect_identical(h_init$h5, mock_h5)
   expect_identical(h_init$subset, init_subset)
+  expect_equal(h_init$run_ids, c("run-01", "run-02"))
+  expect_equal(h_init$current_run_id, "run-01")
 
   # Input validation checks
   expect_error(DataHandle$new(initial_stash = "not_a_list"))


### PR DESCRIPTION
## Summary
- add run identifier fields to DataHandle
- name list inputs in core_write and store run names
- expose run names to transforms via DataHandle
- test default run naming behaviour
- update DataHandle tests for new fields

## Testing
- `devtools::test()` *(fails: `bash: R: command not found`)*