### PR TITLE
Implement has_float16_support helper

### DIFF
--- a/R/utils_float16.R
+++ b/R/utils_float16.R
@@ -1,0 +1,19 @@
+#' Float16 Support Check
+#'
+#' @description Determine whether the current R session can handle
+#' half-precision (float16) numeric types. This helper looks for
+#' optional packages known to provide such support. If none are found,
+#' the function returns `FALSE`. For Phase 1 this is effectively a
+#' stub and will typically return `FALSE`.
+#'
+#' @return Logical scalar indicating availability of float16 support.
+#' @keywords internal
+has_float16_support <- function() {
+  pkgs <- c("float16", "bit64c")
+  for (p in pkgs) {
+    if (requireNamespace(p, quietly = TRUE)) {
+      return(TRUE)
+    }
+  }
+  FALSE
+}

--- a/tests/testthat/test-utils_float16.R
+++ b/tests/testthat/test-utils_float16.R
@@ -1,0 +1,18 @@
+library(testthat)
+
+# Basic behaviour of has_float16_support
+
+test_that("has_float16_support returns logical scalar", {
+  res <- has_float16_support()
+  expect_type(res, "logical")
+  expect_length(res, 1)
+})
+
+test_that("has_float16_support detects packages", {
+  with_mocked_bindings(
+    requireNamespace = function(pkg, quietly = TRUE) TRUE,
+    {
+      expect_true(has_float16_support())
+    }
+  )
+})


### PR DESCRIPTION
## Summary
- add `has_float16_support()` helper checking for optional packages
- test the helper logic

## Testing
- `Rscript -e 'devtools::test()'` *(fails: command not found)*