### PR TITLE
Implement mask handling in core_write

### DIFF
--- a/R/api.R
+++ b/R/api.R
@@ -7,17 +7,19 @@
 #' @param file Path to output `.h5` file. If `NULL`, a temporary file is used.
 #' @param transforms Character vector of transform types.
 #' @param transform_params Named list of transform parameters.
+#' @param mask Optional mask passed to `core_write`.
 #' @return Invisibly returns a list with elements `file`, `plan`, and
 #'   `header` with class `"lna_write_result"`.
 #' @export
 write_lna <- function(x, file = NULL, transforms = character(),
-                      transform_params = list()) {
+                      transform_params = list(), mask = NULL) {
   if (is.null(file)) {
     file <- tempfile(fileext = ".h5")
   }
 
   result <- core_write(x = x, transforms = transforms,
-                       transform_params = transform_params)
+                       transform_params = transform_params,
+                       mask = mask)
 
   h5 <- hdf5r::H5File$new(file, mode = "w")
   materialise_plan(h5, result$plan)

--- a/R/core_write.R
+++ b/R/core_write.R
@@ -9,12 +9,24 @@
 #'
 #' @return A list with `handle` and `plan` objects.
 #' @keywords internal
-core_write <- function(x, transforms, transform_params = list()) {
+core_write <- function(x, transforms, transform_params = list(), mask = NULL) {
   stopifnot(is.character(transforms))
   stopifnot(is.list(transform_params))
 
-  # --- Stub: derive initial mask/header from `x` ---
-  mask <- NULL
+  # --- Validate and store mask ---
+  mask_array <- NULL
+  active_voxels <- NULL
+  if (!is.null(mask)) {
+    if (inherits(mask, "LogicalNeuroVol")) {
+      mask_array <- as.array(mask)
+    } else if (is.array(mask) && length(dim(mask)) == 3 && is.logical(mask)) {
+      mask_array <- mask
+    } else {
+      abort_lna("mask must be LogicalNeuroVol or 3D logical array",
+                .subclass = "lna_error_validation")
+    }
+    active_voxels <- sum(mask_array)
+  }
   header <- list()
 
   # --- Determine run identifiers ---
@@ -27,14 +39,35 @@ core_write <- function(x, transforms, transform_params = list()) {
     run_ids <- "run-01"
   }
 
+  if (!is.null(mask_array)) {
+    check_mask <- function(obj) {
+      dims <- dim(obj)
+      if (is.null(dims) || length(dims) < 3) {
+        abort_lna("input data must have at least 3 dimensions for mask check",
+                  .subclass = "lna_error_validation")
+      }
+      voxel_count <- prod(dims[1:3])
+      if (active_voxels != voxel_count) {
+        abort_lna("mask voxel count mismatch", .subclass = "lna_error_validation")
+      }
+    }
+    if (is.list(x)) {
+      lapply(x, check_mask)
+    } else {
+      check_mask(x)
+    }
+  }
+
   # --- Create plan and initial handle ---
   plan <- Plan$new()
   handle <- DataHandle$new(
     initial_stash = list(input = x),
-    initial_meta = list(mask = mask, header = header),
+    initial_meta = list(mask = mask_array, header = header),
     plan = plan,
     run_ids = run_ids,
-    current_run_id = run_ids[1]
+    current_run_id = run_ids[1],
+    mask_info = if (!is.null(mask_array)) list(mask = mask_array,
+                                             active_voxels = active_voxels) else NULL
   )
 
   # --- Resolve parameters with defaults and package options ---

--- a/R/handle.R
+++ b/R/handle.R
@@ -22,6 +22,8 @@ DataHandle <- R6::R6Class("DataHandle",
     run_ids = NULL,
     #' @field current_run_id The run identifier currently being processed.
     current_run_id = NULL,
+    #' @field mask_info List with mask array and active voxel count
+    mask_info = NULL,
 
     #' @description
     #' Initialize a new DataHandle object.
@@ -32,7 +34,7 @@ DataHandle <- R6::R6Class("DataHandle",
     #' @param subset A list specifying subsetting (optional, for reading).
     initialize = function(initial_stash = list(), initial_meta = list(), plan = NULL,
                           h5 = NULL, subset = list(), run_ids = character(),
-                          current_run_id = NULL) {
+                          current_run_id = NULL, mask_info = NULL) {
       # Basic input validation
       stopifnot(is.list(initial_stash))
       stopifnot(is.list(initial_meta))
@@ -58,6 +60,7 @@ DataHandle <- R6::R6Class("DataHandle",
       self$subset <- subset
       self$run_ids <- run_ids
       self$current_run_id <- current_run_id
+      self$mask_info <- mask_info
     },
 
     #' @description

--- a/tests/testthat/test-core_write.R
+++ b/tests/testthat/test-core_write.R
@@ -78,3 +78,20 @@ test_that("unnamed list input generates run names accessible to forward_step", {
   expect_equal(res$handle$run_ids, c("run-01", "run-02"))
   expect_equal(res$handle$current_run_id, "run-01")
 })
+
+test_that("mask is validated and stored", {
+  arr <- array(1, dim = c(2,2,2,3))
+  msk <- array(TRUE, dim = c(2,2,2))
+  res <- core_write(x = arr, transforms = "tA", mask = msk)
+  expect_equal(res$handle$mask_info$active_voxels, sum(msk))
+  expect_true(all(res$handle$meta$mask == msk))
+})
+
+test_that("mask voxel mismatch triggers error", {
+  arr <- array(1, dim = c(2,2,2,1))
+  bad <- array(c(rep(TRUE,7), FALSE), dim = c(2,2,2))
+  expect_error(
+    core_write(x = arr, transforms = "tA", mask = bad),
+    class = "lna_error_validation"
+  )
+})

--- a/tests/testthat/test-handle.R
+++ b/tests/testthat/test-handle.R
@@ -30,6 +30,7 @@ test_that("DataHandle initialization works correctly", {
   expect_equal(length(h_default$subset), 0)
   expect_equal(h_default$run_ids, character(0))
   expect_null(h_default$current_run_id)
+  expect_null(h_default$mask_info)
 
   # Initialization with values
   init_stash <- list(a = 1, b = "hello")
@@ -52,6 +53,7 @@ test_that("DataHandle initialization works correctly", {
   expect_identical(h_init$subset, init_subset)
   expect_equal(h_init$run_ids, c("run-01", "run-02"))
   expect_equal(h_init$current_run_id, "run-01")
+  expect_null(h_init$mask_info)
 
   # Input validation checks
   expect_error(DataHandle$new(initial_stash = "not_a_list"))


### PR DESCRIPTION
## Summary
- add mask_info field to DataHandle
- validate and store mask in `core_write`
- expose `mask` argument via `write_lna`
- test mask validation and DataHandle initialization

## Testing
- `R` command not available; could not run devtools tests