### PR TITLE
Implement header writing & in-memory option

### DIFF
--- a/R/core_write.R
+++ b/R/core_write.R
@@ -6,10 +6,13 @@
 #' @param x An input object to be written.
 #' @param transforms Character vector of transform types (forward order).
 #' @param transform_params Named list of user supplied parameters for transforms.
+#' @param mask Optional mask object passed through to transforms.
+#' @param header Optional named list of header attributes.
 #'
 #' @return A list with `handle` and `plan` objects.
 #' @keywords internal
-core_write <- function(x, transforms, transform_params = list(), mask = NULL) {
+core_write <- function(x, transforms, transform_params = list(),
+                       mask = NULL, header = NULL) {
   stopifnot(is.character(transforms))
   stopifnot(is.list(transform_params))
 
@@ -27,7 +30,15 @@ core_write <- function(x, transforms, transform_params = list(), mask = NULL) {
     }
     active_voxels <- sum(mask_array)
   }
-  header <- list()
+  if (!is.null(header)) {
+    stopifnot(is.list(header))
+    if (is.null(names(header)) || any(names(header) == "")) {
+      abort_lna("header must be a named list", .subclass = "lna_error_validation")
+    }
+    header_list <- header
+  } else {
+    header_list <- list()
+  }
 
   # --- Determine run identifiers ---
   if (is.list(x)) {
@@ -62,7 +73,7 @@ core_write <- function(x, transforms, transform_params = list(), mask = NULL) {
   plan <- Plan$new()
   handle <- DataHandle$new(
     initial_stash = list(input = x),
-    initial_meta = list(mask = mask_array, header = header),
+    initial_meta = list(mask = mask_array, header = header_list),
     plan = plan,
     run_ids = run_ids,
     current_run_id = run_ids[1],

--- a/tests/testthat/test-materialise_plan.R
+++ b/tests/testthat/test-materialise_plan.R
@@ -33,3 +33,17 @@ test_that("materialise_plan creates structure and updates plan", {
   expect_true(h5$is_valid())
   h5$close_all()
 })
+
+test_that("materialise_plan writes header attributes", {
+  tmp <- local_tempfile(fileext = ".h5")
+  h5 <- H5File$new(tmp, mode = "w")
+  plan <- Plan$new()
+
+  materialise_plan(h5, plan, header = list(vox = 1L, note = "hi"))
+
+  expect_true(h5$exists("header/global"))
+  grp <- h5[["header/global"]]
+  expect_identical(h5_attr_read(grp, "vox"), 1L)
+  expect_identical(h5_attr_read(grp, "note"), "hi")
+  h5$close_all()
+})


### PR DESCRIPTION
## Summary
- add `header` argument support through `core_write`, `materialise_plan`, and `write_lna`
- allow `write_lna(file=NULL)` to create in-memory files using HDF5 core driver
- write header attributes into `/header/global`
- update unit tests for new behaviour

## Testing
- `devtools::test()` *(fails: `R` not installed)*