### PR TITLE
Implement M1-10 and M1-11 features

### DIFF
--- a/R/api.R
+++ b/R/api.R
@@ -38,10 +38,17 @@ write_lna <- function(x, file = NULL, transforms = character(),
 #' @param file Path to an LNA file on disk.
 #' @param allow_plugins Forwarded to `core_read`.
 #' @param validate Logical flag for validation; forwarded to `core_read`.
+#' @param output_dtype Desired output data type. One of
+#'   `"float32"`, `"float64"`, or `"float16"`.
+#' @param lazy Logical. If `TRUE`, the HDF5 file remains open and the
+#'   returned handle can be used for lazy reading (Phase 1 stub).
 #' @return A `DataHandle` object from `core_read`.
 #' @export
 read_lna <- function(file, allow_plugins = c("warn", "off", "on"),
-                     validate = FALSE) {
+                     validate = FALSE,
+                     output_dtype = c("float32", "float64", "float16"),
+                     lazy = FALSE) {
   core_read(file = file, allow_plugins = allow_plugins,
-            validate = validate)
+            validate = validate, output_dtype = output_dtype,
+            lazy = lazy)
 }

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -49,16 +49,27 @@ test_that("write_lna forwards arguments to core_write and materialise_plan", {
 test_that("read_lna forwards arguments to core_read", {
   captured <- list()
   with_mocked_bindings(
-    core_read = function(file, allow_plugins, validate) {
+    core_read = function(file, allow_plugins, validate, output_dtype, lazy) {
       captured$core <- list(file = file, allow_plugins = allow_plugins,
-                            validate = validate)
+                            validate = validate, output_dtype = output_dtype,
+                            lazy = lazy)
       DataHandle$new()
     }, {
-      read_lna("somefile.h5", allow_plugins = "on", validate = TRUE)
+      read_lna("somefile.h5", allow_plugins = "on", validate = TRUE,
+               output_dtype = "float64", lazy = TRUE)
     }
   )
 
   expect_equal(captured$core$file, "somefile.h5")
   expect_equal(captured$core$allow_plugins, "on")
   expect_true(captured$core$validate)
+  expect_equal(captured$core$output_dtype, "float64")
+  expect_true(captured$core$lazy)
+})
+
+test_that("read_lna lazy=TRUE keeps file open", {
+  result <- write_lna(x = 1, file = NULL, transforms = character(0))
+  handle <- read_lna(result$file, lazy = TRUE)
+  expect_true(handle$h5$is_valid())
+  handle$h5$close_all()
 })


### PR DESCRIPTION
## Summary
- extend `read_lna`/`core_read` with `lazy` and `output_dtype`
- implement float16 error handling and record requested output dtype
- update API wrapper tests
- add new tests for `core_read` lazy mode and dtype handling

## Testing
- `R CMD check` *(fails: `R` not installed)*