### PR TITLE
Add HDF5 helpers and tests

### DIFF
--- a/R/utils_hdf5.R
+++ b/R/utils_hdf5.R
@@ -202,3 +202,83 @@ h5_write_dataset <- function(h5_group, path, data,
 
   invisible(dset)
 }
+
+#' Assert that an HDF5 path exists
+#'
+#' Convenience helper to verify that a dataset or group is present
+#' at the given path relative to `h5`. Throws an `lna_error_missing_path`
+#' error if the path does not exist.
+#'
+#' @param h5 An `H5File` or `H5Group` object.
+#' @param path Character path to check.
+#' @return Invisibly returns `NULL` when the path exists.
+#' @keywords internal
+assert_h5_path <- function(h5, path) {
+  stopifnot(inherits(h5, c("H5File", "H5Group")))
+  stopifnot(is.character(path), length(path) == 1)
+
+  if (!h5$exists(path)) {
+    abort_lna(
+      sprintf("HDF5 path '%s' not found", path),
+      .subclass = "lna_error_missing_path"
+    )
+  }
+  invisible(NULL)
+}
+
+#' Map a datatype name to an HDF5 type
+#'
+#' Provides a small lookup used when creating datasets. The mapping is
+#' intentionally simple but can be extended to support NIfTI conversions.
+#'
+#' @param dtype Character scalar naming the datatype.
+#' @return An `H5T` object.
+#' @keywords internal
+map_dtype <- function(dtype) {
+  if (inherits(dtype, "H5T")) {
+    return(dtype)
+  }
+
+  stopifnot(is.character(dtype), length(dtype) == 1)
+
+  switch(dtype,
+    float32 = hdf5r::h5types$H5T_IEEE_F32LE,
+    float64 = hdf5r::h5types$H5T_IEEE_F64LE,
+    int8    = hdf5r::h5types$H5T_STD_I8LE,
+    uint8   = hdf5r::h5types$H5T_STD_U8LE,
+    int16   = hdf5r::h5types$H5T_STD_I16LE,
+    uint16  = hdf5r::h5types$H5T_STD_U16LE,
+    int32   = hdf5r::h5types$H5T_STD_I32LE,
+    uint32  = hdf5r::h5types$H5T_STD_U32LE,
+    int64   = hdf5r::h5types$H5T_STD_I64LE,
+    uint64  = hdf5r::h5types$H5T_STD_U64LE,
+    abort_lna(
+      sprintf("Unknown dtype '%s'", dtype),
+      .subclass = "lna_error_validation"
+    )
+  )
+}
+
+#' Guess an HDF5 datatype for an R object
+#'
+#' @param x R object to inspect.
+#' @return An `H5T` datatype object.
+#' @keywords internal
+guess_h5_type <- function(x) {
+  if (is.integer(x)) {
+    return(map_dtype("int32"))
+  } else if (is.double(x)) {
+    return(map_dtype("float64"))
+  } else if (is.logical(x) || is.raw(x)) {
+    return(map_dtype("uint8"))
+  } else if (is.character(x)) {
+    t <- hdf5r::H5T_STRING$new(size = Inf)
+    t$set_cset("UTF-8")
+    return(t)
+  }
+
+  abort_lna(
+    "Unsupported object type for HDF5 storage",
+    .subclass = "lna_error_validation"
+  )
+}

--- a/R/utils_json.R
+++ b/R/utils_json.R
@@ -18,14 +18,7 @@ read_json_descriptor <- function(h5_group, name) {
   stopifnot(inherits(h5_group, "H5Group")) # Basic type check
   stopifnot(is.character(name), length(name) == 1)
 
-  
-  if (!h5_group$exists(name)) {
-    # Or should this error? Returning NULL allows checking existence implicitly.
-    # Let's error for now, as descriptors are usually expected.
-    # TODO: Revisit error handling based on usage context.
-    stop(paste("JSON descriptor dataset '", name, "' not found in HDF5 group.", sep = ""))
-    # return(NULL)
-  }
+  assert_h5_path(h5_group, name)
 
 
   dset <- NULL

--- a/tests/testthat/test-utils_hdf5.R
+++ b/tests/testthat/test-utils_hdf5.R
@@ -127,4 +127,28 @@ test_that("HDF5 attribute helpers handle edge cases and errors", {
   expect_null(h5_attr_delete(root_group, "does_not_exist"))
 
   h5_file$close_all()
-}) 
+})
+
+test_that("assert_h5_path validates paths", {
+  tmp <- local_tempfile(fileext = ".h5")
+  h5 <- H5File$new(tmp, mode = "w")
+  root <- h5[["/"]]
+  root$create_group("exists")
+
+  expect_invisible(assert_h5_path(h5, "exists"))
+  expect_error(assert_h5_path(h5, "missing"), class = "lna_error_missing_path")
+
+  h5$close_all()
+})
+
+test_that("map_dtype and guess_h5_type return H5T objects", {
+  t1 <- map_dtype("float32")
+  expect_true(inherits(t1, "H5T"))
+  expect_equal(t1$get_size(), 4)
+
+  t2 <- guess_h5_type(1L)
+  expect_true(inherits(t2, "H5T"))
+  expect_equal(t2$get_size(), 4)
+
+  expect_error(map_dtype("bogus"), class = "lna_error_validation")
+})


### PR DESCRIPTION
## Summary
- add `assert_h5_path`, `map_dtype`, and `guess_h5_type` helpers
- use `assert_h5_path` when reading JSON descriptors
- test new helpers

## Testing
- `R CMD build .` *(fails: command not found)*
- `Rscript -e 'library(testthat); test_dir("tests/testthat")'` *(fails: command not found)*