### PR TITLE
Add HDF5 open/close helpers

### DIFF
--- a/R/api.R
+++ b/R/api.R
@@ -27,13 +27,12 @@ write_lna <- function(x, file = NULL, transforms = character(),
                        mask = mask, header = header)
 
   if (in_memory) {
-    h5 <- hdf5r::H5File$new(file, mode = "w", driver = "core",
-                            backing_store = FALSE)
+    h5 <- open_h5(file, mode = "w", driver = "core", backing_store = FALSE)
   } else {
-    h5 <- hdf5r::H5File$new(file, mode = "w")
+    h5 <- open_h5(file, mode = "w")
   }
   materialise_plan(h5, result$plan, header = result$handle$meta$header)
-  h5$close_all()
+  close_h5_safely(h5)
 
   out_file <- if (in_memory) NULL else file
   out <- list(file = out_file, plan = result$plan,

--- a/R/core_read.R
+++ b/R/core_read.R
@@ -21,11 +21,9 @@ core_read <- function(file, allow_plugins = c("warn", "off", "on"), validate = F
                       lazy = FALSE) {
   allow_plugins <- match.arg(allow_plugins)
   output_dtype <- match.arg(output_dtype)
-  h5 <- H5File$new(file, mode = "r")
+  h5 <- open_h5(file, mode = "r")
   if (!lazy) {
-    on.exit({
-      if (inherits(h5, "H5File") && h5$is_valid()) h5$close_all()
-    })
+    on.exit(close_h5_safely(h5))
   }
 
   handle <- DataHandle$new(h5 = h5)

--- a/R/materialise.R
+++ b/R/materialise.R
@@ -98,13 +98,13 @@ materialise_plan <- function(h5, plan, checksum = c("none", "sha256"),
 
   if (checksum == "sha256") {
     file_path <- h5$filename
-    h5$close_all()
+    close_h5_safely(h5)
     if (is.character(file_path) && nzchar(file_path) && file.exists(file_path)) {
       hash_val <- digest::digest(file = file_path, algo = "sha256")
-      h5_tmp <- hdf5r::H5File$new(file_path, mode = "r+")
+      h5_tmp <- open_h5(file_path, mode = "r+")
       root_tmp <- h5_tmp[["/"]]
       h5_attr_write(root_tmp, "lna_checksum", hash_val)
-      h5_tmp$close_all()
+      close_h5_safely(h5_tmp)
     } else {
       warning("Checksum requested but file path unavailable; skipping")
     }

--- a/R/utils_hdf5.R
+++ b/R/utils_hdf5.R
@@ -202,3 +202,45 @@ h5_write_dataset <- function(h5_group, path, data,
 
   invisible(dset)
 }
+
+#' Open an HDF5 file with basic error handling
+#'
+#' Wrapper around `hdf5r::H5File$new` that throws a clearer error message on
+#' failure.
+#'
+#' @param path Path to the HDF5 file.
+#' @param mode File mode passed to `H5File$new`.
+#' @param ... Additional arguments forwarded to `H5File$new`.
+#' @return An `H5File` object.
+#' @keywords internal
+open_h5 <- function(path, mode = "r", ...) {
+  stopifnot(is.character(path), length(path) == 1)
+  stopifnot(is.character(mode), length(mode) == 1)
+
+  tryCatch(
+    hdf5r::H5File$new(path, mode = mode, ...),
+    error = function(e) {
+      stop(
+        sprintf("Failed to open HDF5 file '%s': %s", path, conditionMessage(e)),
+        call. = FALSE
+      )
+    }
+  )
+}
+
+#' Close an HDF5 file handle if valid
+#'
+#' Silently attempts to close an `H5File` handle, ignoring objects that are not
+#' valid file handles.
+#'
+#' @param h5 Object returned by `open_h5`.
+#' @return Invisible `NULL`.
+#' @keywords internal
+close_h5_safely <- function(h5) {
+  if (inherits(h5, "H5File") && h5$is_valid()) {
+    tryCatch(h5$close_all(), error = function(e) {
+      warning(paste("Error closing HDF5 handle:", conditionMessage(e)))
+    })
+  }
+  invisible(NULL)
+}

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -16,10 +16,10 @@ test_that("write_lna writes header attributes to file", {
   result <- write_lna(x = 1, file = tmp, transforms = character(0),
                       header = list(foo = 2L))
   expect_true(file.exists(tmp))
-  h5 <- H5File$new(tmp, mode = "r")
+  h5 <- neuroarchive:::open_h5(tmp, mode = "r")
   grp <- h5[["header/global"]]
   expect_identical(h5_attr_read(grp, "foo"), 2L)
-  h5$close_all()
+  neuroarchive:::close_h5_safely(h5)
 })
 
 # Parameter forwarding for write_lna
@@ -83,5 +83,5 @@ test_that("read_lna lazy=TRUE keeps file open", {
   result <- write_lna(x = 1, file = NULL, transforms = character(0))
   handle <- read_lna(result$file, lazy = TRUE)
   expect_true(handle$h5$is_valid())
-  handle$h5$close_all()
+  neuroarchive:::close_h5_safely(handle$h5)
 })

--- a/tests/testthat/test-core_read.R
+++ b/tests/testthat/test-core_read.R
@@ -7,17 +7,17 @@ library(withr)
 
 # Helper to create empty transforms group
 create_empty_lna <- function(path) {
-  h5 <- H5File$new(path, mode = "w")
+  h5 <- neuroarchive:::open_h5(path, mode = "w")
   h5$create_group("transforms")
-  h5$close_all()
+  neuroarchive:::close_h5_safely(h5)
 }
 
 # Helper to create lna with one dummy descriptor
 create_dummy_lna <- function(path) {
-  h5 <- H5File$new(path, mode = "w")
+  h5 <- neuroarchive:::open_h5(path, mode = "w")
   tf <- h5$create_group("transforms")
   write_json_descriptor(tf, "00_dummy.json", list(type = "dummy"))
-  h5$close_all()
+  neuroarchive:::close_h5_safely(h5)
 }
 
 test_that("core_read handles empty /transforms group", {
@@ -51,7 +51,7 @@ test_that("core_read lazy=TRUE keeps file open", {
 
   handle <- core_read(tmp, lazy = TRUE)
   expect_true(handle$h5$is_valid())
-  handle$h5$close_all()
+  neuroarchive:::close_h5_safely(handle$h5)
 })
 
 test_that("core_read output_dtype stored and float16 check", {
@@ -74,7 +74,7 @@ test_that("core_read allows float16 when support present", {
       h <- core_read(tmp, output_dtype = "float16")
       expect_equal(h$meta$output_dtype, "float16")
       expect_true(h$h5$is_valid())
-      h$h5$close_all()
+      neuroarchive:::close_h5_safely(h$h5)
     }
   )
 })

--- a/tests/testthat/test-h5_open_close.R
+++ b/tests/testthat/test-h5_open_close.R
@@ -1,0 +1,24 @@
+library(testthat)
+library(hdf5r)
+library(withr)
+
+# Tests for open_h5 and close_h5_safely helpers
+
+test_that("open_h5 creates and closes files", {
+  tmp <- local_tempfile(fileext = ".h5")
+  h5 <- neuroarchive:::open_h5(tmp, mode = "w")
+  expect_s3_class(h5, "H5File")
+  expect_true(h5$is_valid())
+  neuroarchive:::close_h5_safely(h5)
+  expect_false(h5$is_valid())
+})
+
+test_that("open_h5 errors for missing file", {
+  missing <- file.path(tempdir(), "does_not_exist.h5")
+  expect_error(neuroarchive:::open_h5(missing, mode = "r"), "Failed to open HDF5 file")
+})
+
+test_that("close_h5_safely tolerates invalid objects", {
+  expect_silent(neuroarchive:::close_h5_safely(NULL))
+  expect_silent(neuroarchive:::close_h5_safely("not a handle"))
+})

--- a/tests/testthat/test-h5_write_dataset.R
+++ b/tests/testthat/test-h5_write_dataset.R
@@ -6,7 +6,7 @@ library(withr)
 
 test_that("h5_write_dataset writes dataset with compression", {
   tmp <- local_tempfile(fileext = ".h5")
-  h5 <- H5File$new(tmp, mode = "w")
+  h5 <- neuroarchive:::open_h5(tmp, mode = "w")
   root <- h5[["/"]]
 
   mat <- matrix(1:9, nrow = 3)
@@ -24,5 +24,5 @@ test_that("h5_write_dataset writes dataset with compression", {
 
   dcpl$close()
   dset$close()
-  h5$close_all()
+  neuroarchive:::close_h5_safely(h5)
 })

--- a/tests/testthat/test-materialise_checksum.R
+++ b/tests/testthat/test-materialise_checksum.R
@@ -7,7 +7,7 @@ library(digest)
 
 test_that("materialise_plan writes sha256 checksum attribute", {
   tmp <- local_tempfile(fileext = ".h5")
-  h5 <- H5File$new(tmp, mode = "w")
+  h5 <- neuroarchive:::open_h5(tmp, mode = "w")
   plan <- Plan$new()
   plan$add_descriptor("00_dummy.json", list(type = "dummy"))
   plan$add_payload("payload", matrix(1:4, nrow = 2))
@@ -16,10 +16,10 @@ test_that("materialise_plan writes sha256 checksum attribute", {
   materialise_plan(h5, plan, checksum = "sha256")
 
   expect_false(h5$is_valid())
-  h5r <- H5File$new(tmp, mode = "r")
+  h5r <- neuroarchive:::open_h5(tmp, mode = "r")
   root <- h5r[["/"]]
   expect_true(h5_attr_exists(root, "lna_checksum"))
   expected <- digest(file = tmp, algo = "sha256")
   expect_identical(h5_attr_read(root, "lna_checksum"), expected)
-  h5r$close_all()
+  neuroarchive:::close_h5_safely(h5r)
 })

--- a/tests/testthat/test-materialise_plan.R
+++ b/tests/testthat/test-materialise_plan.R
@@ -6,7 +6,7 @@ library(withr)
 
 test_that("materialise_plan creates structure and updates plan", {
   tmp <- local_tempfile(fileext = ".h5")
-  h5 <- H5File$new(tmp, mode = "w")
+  h5 <- neuroarchive:::open_h5(tmp, mode = "w")
   plan <- Plan$new()
   plan$add_descriptor("00_dummy.json", list(type = "dummy"))
   plan$add_payload("payload", matrix(1:4, nrow = 2))
@@ -31,12 +31,12 @@ test_that("materialise_plan creates structure and updates plan", {
   expect_true(h5$exists("scans/run-01/data"))
   expect_equal(h5[["scans/run-01/data"]]$read(), matrix(1:4, nrow = 2))
   expect_true(h5$is_valid())
-  h5$close_all()
+  neuroarchive:::close_h5_safely(h5)
 })
 
 test_that("materialise_plan writes header attributes", {
   tmp <- local_tempfile(fileext = ".h5")
-  h5 <- H5File$new(tmp, mode = "w")
+  h5 <- neuroarchive:::open_h5(tmp, mode = "w")
   plan <- Plan$new()
 
   materialise_plan(h5, plan, header = list(vox = 1L, note = "hi"))
@@ -45,5 +45,5 @@ test_that("materialise_plan writes header attributes", {
   grp <- h5[["header/global"]]
   expect_identical(h5_attr_read(grp, "vox"), 1L)
   expect_identical(h5_attr_read(grp, "note"), "hi")
-  h5$close_all()
+  neuroarchive:::close_h5_safely(h5)
 })


### PR DESCRIPTION
## Summary
- add `open_h5` and `close_h5_safely` utilities
- refactor code to use these helpers
- extend tests to cover helper behaviour and update existing tests

## Testing
- `R --version` *(fails: command not found)*