### PR TITLE
Implement lna_reader lazy reader

### DIFF
--- a/R/api.R
+++ b/R/api.R
@@ -58,7 +58,25 @@ read_lna <- function(file, allow_plugins = c("warn", "off", "on"),
                      validate = FALSE,
                      output_dtype = c("float32", "float64", "float16"),
                      lazy = FALSE) {
-  core_read(file = file, allow_plugins = allow_plugins,
-            validate = validate, output_dtype = output_dtype,
-            lazy = lazy)
+  output_dtype <- match.arg(output_dtype)
+  allow_plugins <- match.arg(allow_plugins)
+
+  if (lazy) {
+    lna_reader$new(
+      file = file,
+      core_read_args = list(
+        allow_plugins = allow_plugins,
+        validate = validate,
+        output_dtype = output_dtype
+      )
+    )
+  } else {
+    core_read(
+      file = file,
+      allow_plugins = allow_plugins,
+      validate = validate,
+      output_dtype = output_dtype,
+      lazy = FALSE
+    )
+  }
 }

--- a/R/reader.R
+++ b/R/reader.R
@@ -1,0 +1,110 @@
+#' lna_reader Class for Lazy Reading
+#'
+#' @description Provides deferred data loading from LNA files. The
+#'   reader keeps an HDF5 file handle open and runs the inverse
+#'   transform pipeline on demand via `$data()`. Subsetting parameters
+#'   can be stored with `$subset()`.
+#' @keywords internal
+lna_reader <- R6::R6Class("lna_reader",
+  public = list(
+    #' @field file Path to the underlying LNA file
+    file = NULL,
+    #' @field h5 Open H5File handle
+    h5 = NULL,
+    #' @field core_args List of arguments forwarded to `core_read`
+    core_args = NULL,
+    #' @field subset_params Stored subsetting parameters
+    subset_params = NULL,
+    #' @field data_cache Cached DataHandle from `$data()`
+    data_cache = NULL,
+    #' @field cache_params Parameters used for `data_cache`
+    cache_params = NULL,
+
+    #' @description
+    #' Create a new `lna_reader`
+    #' @param file Path to an LNA file
+    #' @param core_read_args Named list of arguments for `core_read`
+    initialize = function(file, core_read_args) {
+      stopifnot(is.character(file), length(file) == 1)
+      self$file <- file
+      self$core_args <- core_read_args
+      self$subset_params <- list()
+      self$h5 <- open_h5(file, mode = "r")
+    },
+
+    #' @description
+    #' Close the HDF5 handle. Safe to call multiple times.
+    close = function() {
+      if (!is.null(self$h5)) {
+        close_h5_safely(self$h5)
+        self$h5 <- NULL
+      }
+      invisible(NULL)
+    },
+
+    #' @description
+    #' Finalizer called by GC
+    finalize = function() {
+      self$close()
+    },
+
+    #' @description
+    #' Print summary of the reader
+    print = function(...) {
+      status <- if (!is.null(self$h5) && self$h5$is_valid()) "open" else "closed"
+      cat("<lna_reader>", self$file, "[", status, "]\n")
+      invisible(self)
+    },
+
+    #' @description
+    #' Store subsetting parameters for later `$data()` calls.
+    #' @param ... Named parameters such as `roi_mask`, `time_idx`
+    subset = function(...) {
+      args <- list(...)
+      if (length(args) > 0) {
+        self$subset_params <- utils::modifyList(self$subset_params, args,
+                                                keep.null = TRUE)
+      }
+      invisible(self)
+    },
+
+    #' @description
+    #' Load and reconstruct data applying current subsetting.
+    #' @param ... Optional subsetting parameters overriding stored ones
+    #' @return A `DataHandle` object representing the loaded data
+    data = function(...) {
+      args <- list(...)
+      params <- self$subset_params
+      if (length(args) > 0) {
+        params <- utils::modifyList(params, args, keep.null = TRUE)
+      }
+      if (!is.null(self$data_cache) && identical(params, self$cache_params)) {
+        return(self$data_cache)
+      }
+
+      h5 <- self$h5
+      handle <- DataHandle$new(h5 = h5, subset = params)
+      tf_group <- h5[["transforms"]]
+      transforms <- discover_transforms(tf_group)
+      if (nrow(transforms) > 0) {
+        for (i in rev(seq_len(nrow(transforms)))) {
+          name <- transforms$name[[i]]
+          type <- transforms$type[[i]]
+          desc <- read_json_descriptor(tf_group, name)
+          handle <- invert_step(type, desc, handle)
+        }
+      }
+
+      output_dtype <- self$core_args$output_dtype
+      if (identical(output_dtype, "float16") && !has_float16_support()) {
+        abort_lna("float16 output not supported",
+                  .subclass = "lna_error_float16_unsupported")
+      }
+      handle$meta$output_dtype <- output_dtype
+
+      self$data_cache <- handle
+      self$cache_params <- params
+      handle
+    }
+  )
+)

--- a/tests/testthat/test-reader.R
+++ b/tests/testthat/test-reader.R
@@ -1,0 +1,54 @@
+library(testthat)
+library(withr)
+
+# Helper to create simple LNA file with no transforms
+create_empty_lna <- function(path) {
+  h5 <- neuroarchive:::open_h5(path, mode = "w")
+  h5$create_group("transforms")
+  neuroarchive:::close_h5_safely(h5)
+}
+
+
+test_that("read_lna(lazy=TRUE) returns lna_reader", {
+  tmp <- local_tempfile(fileext = ".h5")
+  create_empty_lna(tmp)
+
+  reader <- read_lna(tmp, lazy = TRUE)
+  expect_s3_class(reader, "lna_reader")
+  expect_true(reader$h5$is_valid())
+  reader$close()
+})
+
+
+test_that("lna_reader close is idempotent", {
+  tmp <- local_tempfile(fileext = ".h5")
+  create_empty_lna(tmp)
+
+  reader <- read_lna(tmp, lazy = TRUE)
+  expect_true(reader$h5$is_valid())
+  reader$close()
+  expect_null(reader$h5)
+  expect_silent(reader$close())
+})
+
+
+test_that("lna_reader data caches result and respects subset", {
+  tmp <- local_tempfile(fileext = ".h5")
+  create_empty_lna(tmp)
+
+  reader <- read_lna(tmp, lazy = TRUE)
+  h1 <- reader$data()
+  expect_s3_class(h1, "DataHandle")
+  h2 <- reader$data()
+  expect_identical(h1, h2)
+
+  reader$subset(roi_mask = 1)
+  h3 <- reader$data()
+  expect_false(identical(h1, h3))
+  expect_identical(h3$subset$roi_mask, 1)
+
+  h4 <- reader$data()
+  expect_identical(h3, h4)
+
+  reader$close()
+})


### PR DESCRIPTION
## Summary
- add `lna_reader` R6 class for lazy reading
- integrate reader with `read_lna()` when `lazy=TRUE`
- test reader lifecycle and caching behaviour

## Testing
- `Rscript -e 'testthat::test_dir("tests/testthat", reporter="summary")'` *(fails: `Rscript` not found)*