### PR TITLE
Implement namespace collision check for transforms

### DIFF
--- a/R/utils_scaffold.R
+++ b/R/utils_scaffold.R
@@ -10,6 +10,8 @@ scaffold_transform <- function(type) {
   if (!nzchar(type)) {
     stop("type must be a non-empty string", call. = FALSE)
   }
+
+  check_transform_implementation(type)
   r_path <- file.path("R", sprintf("transform_%s.R", type))
   schema_path <- file.path("inst", "schemas", sprintf("%s.schema.json", type))
   test_path <- file.path("tests", "testthat", sprintf("test-transform_%s.R", type))

--- a/R/utils_transform.R
+++ b/R/utils_transform.R
@@ -1,0 +1,31 @@
+#' Check transform implementation for namespace collisions
+#'
+#' Warns if the provided transform type name collides with
+#' core LNA transforms or with names of base R packages.
+#'
+#' @param type Character scalar transform name.
+#' @return Logical `TRUE` invisibly. Called for side effects (warnings).
+#' @export
+check_transform_implementation <- function(type) {
+  stopifnot(is.character(type), length(type) == 1)
+
+  core <- c("quant", "basis", "embed", "temporal", "delta")
+  base_pkgs <- rownames(installed.packages(priority = "base"))
+
+  msgs <- character()
+  if (type %in% core) {
+    msgs <- c(msgs, "core LNA transform")
+  }
+  if (type %in% base_pkgs) {
+    msgs <- c(msgs, "base R package")
+  }
+  if (length(msgs) > 0) {
+    warning(sprintf(
+      "Transform type '%s' collides with %s namespace",
+      type,
+      paste(msgs, collapse = " and ")
+    ), call. = FALSE)
+  }
+
+  invisible(TRUE)
+}

--- a/tests/testthat/test-check_transform_implementation.R
+++ b/tests/testthat/test-check_transform_implementation.R
@@ -1,0 +1,12 @@
+library(testthat)
+
+# Tests for check_transform_implementation
+
+test_that("warnings emitted for collisions", {
+  expect_warning(check_transform_implementation("quant"), "collides")
+  expect_warning(check_transform_implementation("stats"), "collides")
+})
+
+test_that("no warning for unique name", {
+  expect_warning(check_transform_implementation("myunique"), NA)
+})

--- a/tests/testthat/test-scaffold_transform.R
+++ b/tests/testthat/test-scaffold_transform.R
@@ -16,3 +16,9 @@ test_that("scaffold_transform creates template files", {
   expect_true(any(grepl("forward_step.mycustom", r_lines, fixed = TRUE)))
   expect_true(any(grepl("default_params('mycustom')", r_lines, fixed = TRUE)))
 })
+
+test_that("scaffold_transform warns on namespace collisions", {
+  tmp <- local_tempdir()
+  withr::local_dir(tmp)
+  expect_warning(scaffold_transform("delta"), "namespace")
+})


### PR DESCRIPTION
## Summary
- add helper `check_transform_implementation` to warn of namespace collisions
- call the helper from `scaffold_transform`
- test new helper and scaffold warnings

## Testing
- `Rscript` *(fails: command not found)*