### PR TITLE
Implement M1-23 error context

### DIFF
--- a/R/core_read.R
+++ b/R/core_read.R
@@ -43,8 +43,11 @@ core_read <- function(file, allow_plugins = c("warn", "off", "on"), validate = F
   }
 
   if (identical(output_dtype, "float16") && !has_float16_support()) {
-    abort_lna("float16 output not supported",
-              .subclass = "lna_error_float16_unsupported")
+    abort_lna(
+      "float16 output not supported",
+      .subclass = "lna_error_float16_unsupported",
+      location = sprintf("core_read:%s", file)
+    )
   }
   handle$meta$output_dtype <- output_dtype
 

--- a/R/core_write.R
+++ b/R/core_write.R
@@ -25,15 +25,22 @@ core_write <- function(x, transforms, transform_params = list(),
     } else if (is.array(mask) && length(dim(mask)) == 3 && is.logical(mask)) {
       mask_array <- mask
     } else {
-      abort_lna("mask must be LogicalNeuroVol or 3D logical array",
-                .subclass = "lna_error_validation")
+      abort_lna(
+        "mask must be LogicalNeuroVol or 3D logical array",
+        .subclass = "lna_error_validation",
+        location = "core_write:mask"
+      )
     }
     active_voxels <- sum(mask_array)
   }
   if (!is.null(header)) {
     stopifnot(is.list(header))
     if (is.null(names(header)) || any(names(header) == "")) {
-      abort_lna("header must be a named list", .subclass = "lna_error_validation")
+      abort_lna(
+        "header must be a named list",
+        .subclass = "lna_error_validation",
+        location = "core_write:header"
+      )
     }
     header_list <- header
   } else {
@@ -54,12 +61,19 @@ core_write <- function(x, transforms, transform_params = list(),
     check_mask <- function(obj) {
       dims <- dim(obj)
       if (is.null(dims) || length(dims) < 3) {
-        abort_lna("input data must have at least 3 dimensions for mask check",
-                  .subclass = "lna_error_validation")
+        abort_lna(
+          "input data must have at least 3 dimensions for mask check",
+          .subclass = "lna_error_validation",
+          location = "core_write:mask_check"
+        )
       }
       voxel_count <- prod(dims[1:3])
       if (active_voxels != voxel_count) {
-        abort_lna("mask voxel count mismatch", .subclass = "lna_error_validation")
+        abort_lna(
+          "mask voxel count mismatch",
+          .subclass = "lna_error_validation",
+          location = "core_write:mask_check"
+        )
       }
     }
     if (is.list(x)) {

--- a/R/discover.R
+++ b/R/discover.R
@@ -98,7 +98,8 @@ discover_transforms <- function(h5_group) {
         "Transform descriptor indices are not contiguous starting from 0. Found indices: ",
         paste(sorted_df$index, collapse = ", ")
       ),
-      .subclass = "lna_error_sequence"
+      .subclass = "lna_error_sequence",
+      location = "discover_transforms"
     )
   }
 

--- a/R/dispatch.R
+++ b/R/dispatch.R
@@ -31,7 +31,8 @@ forward_step.default <- function(type, desc, handle) {
       "No forward_step method implemented for transform type: %s",
       type
     ),
-    .subclass = "lna_error_no_method"
+    .subclass = "lna_error_no_method",
+    location = sprintf("forward_step:%s", type)
   )
 }
 
@@ -61,6 +62,7 @@ invert_step.default <- function(type, desc, handle) {
       "No invert_step method implemented for transform type: %s",
       type
     ),
-    .subclass = "lna_error_no_method"
+    .subclass = "lna_error_no_method",
+    location = sprintf("invert_step:%s", type)
   )
 }

--- a/R/handle.R
+++ b/R/handle.R
@@ -80,7 +80,8 @@ DataHandle <- R6::R6Class("DataHandle",
             paste(missing_keys, collapse = ", ")
           ),
           .subclass = "lna_error_contract",
-          missing_keys = missing_keys
+          missing_keys = missing_keys,
+          location = "DataHandle$get_inputs"
         )
       }
       return(self$stash[keys])

--- a/R/materialise.R
+++ b/R/materialise.R
@@ -66,9 +66,14 @@ materialise_plan <- function(h5, plan, checksum = c("none", "sha256"),
     }
 
     if (inherits(res, "error")) {
-      abort_lna(sprintf("Failed to write dataset '%s' (step %d): %s",
-                        path, step_index, conditionMessage(res)),
-                .subclass = "lna_error_hdf5_write")
+      abort_lna(
+        sprintf(
+          "Failed to write dataset '%s' (step %d): %s",
+          path, step_index, conditionMessage(res)
+        ),
+        .subclass = "lna_error_hdf5_write",
+        location = sprintf("materialise_plan:%s", path)
+      )
     }
   }
 

--- a/R/reader.R
+++ b/R/reader.R
@@ -97,8 +97,11 @@ lna_reader <- R6::R6Class("lna_reader",
 
       output_dtype <- self$core_args$output_dtype
       if (identical(output_dtype, "float16") && !has_float16_support()) {
-        abort_lna("float16 output not supported",
-                  .subclass = "lna_error_float16_unsupported")
+        abort_lna(
+          "float16 output not supported",
+          .subclass = "lna_error_float16_unsupported",
+          location = sprintf("lna_reader:data:%s", self$file)
+        )
       }
       handle$meta$output_dtype <- output_dtype
 

--- a/R/utils_defaults.R
+++ b/R/utils_defaults.R
@@ -98,7 +98,8 @@ resolve_transform_params <- function(transforms, transform_params = list()) {
     if (is.null(names(transform_params)) || any(names(transform_params) == "")) {
       abort_lna(
         "transform_params must be a named list",
-        .subclass = "lna_error_validation"
+        .subclass = "lna_error_validation",
+        location = "resolve_transform_params"
       )
     }
 
@@ -109,7 +110,8 @@ resolve_transform_params <- function(transforms, transform_params = list()) {
           "Unknown transform(s) in transform_params: ",
           paste(unknown, collapse = ", ")
         ),
-        .subclass = "lna_error_validation"
+        .subclass = "lna_error_validation",
+        location = "resolve_transform_params"
       )
     }
   }

--- a/R/utils_error.R
+++ b/R/utils_error.R
@@ -9,8 +9,8 @@
 #' @param .subclass Character string giving the LNA error subclass.
 #' @return No return value. This function always throws an error.
 #' @keywords internal
-abort_lna <- function(message, ..., .subclass) {
+abort_lna <- function(message, ..., .subclass, location = NULL) {
   stopifnot(is.character(message), length(message) == 1)
   stopifnot(is.character(.subclass), length(.subclass) == 1)
-  rlang::abort(message, ..., .subclass = .subclass)
+  rlang::abort(message, ..., .subclass = .subclass, location = location)
 }

--- a/R/utils_hdf5.R
+++ b/R/utils_hdf5.R
@@ -263,7 +263,8 @@ assert_h5_path <- function(h5, path) {
   if (!h5$exists(path)) {
     abort_lna(
       sprintf("HDF5 path '%s' not found", path),
-      .subclass = "lna_error_missing_path"
+      .subclass = "lna_error_missing_path",
+      location = sprintf("assert_h5_path:%s", path)
     )
   }
   invisible(NULL)
@@ -297,7 +298,8 @@ map_dtype <- function(dtype) {
     uint64  = hdf5r::h5types$H5T_STD_U64LE,
     abort_lna(
       sprintf("Unknown dtype '%s'", dtype),
-      .subclass = "lna_error_validation"
+      .subclass = "lna_error_validation",
+      location = "map_dtype"
     )
   )
 }
@@ -322,7 +324,8 @@ guess_h5_type <- function(x) {
 
   abort_lna(
     "Unsupported object type for HDF5 storage",
-    .subclass = "lna_error_validation"
+    .subclass = "lna_error_validation",
+    location = "guess_h5_type"
   )
 }
 

--- a/R/validate.R
+++ b/R/validate.R
@@ -23,7 +23,11 @@ validate_lna <- function(file, strict = TRUE, checksum = TRUE) {
 
   fail <- function(msg) {
     if (strict) {
-      abort_lna(msg, .subclass = "lna_error_validation")
+      abort_lna(
+        msg,
+        .subclass = "lna_error_validation",
+        location = sprintf("validate_lna:%s", file)
+      )
     } else {
       warning(msg)
       return(FALSE)

--- a/tests/testthat/test-core_read.R
+++ b/tests/testthat/test-core_read.R
@@ -60,8 +60,11 @@ test_that("core_read output_dtype stored and float16 check", {
 
   h <- core_read(tmp, output_dtype = "float64")
   expect_equal(h$meta$output_dtype, "float64")
-  expect_error(core_read(tmp, output_dtype = "float16"),
-               class = "lna_error_float16_unsupported")
+  err <- expect_error(
+    core_read(tmp, output_dtype = "float16"),
+    class = "lna_error_float16_unsupported"
+  )
+  expect_true(grepl("core_read", err$location))
 })
 
 test_that("core_read allows float16 when support present", {

--- a/tests/testthat/test-handle.R
+++ b/tests/testthat/test-handle.R
@@ -108,6 +108,7 @@ test_that("DataHandle get_inputs works correctly", {
   # Check the custom data attached to the condition
   expect_true(!is.null(err$missing_keys))
   expect_equal(sort(err$missing_keys), c("d", "e"))
+  expect_true(grepl("DataHandle$get_inputs", err$location))
 
   # Error on invalid key type
   expect_error(h$get_inputs(123))


### PR DESCRIPTION
## Summary
- update `abort_lna` to accept `location`
- attach location metadata for errors in core write/read, materialise, dispatch, etc.
- propagate location info through helper utilities
- adjust tests for new error fields

## Testing
- `R CMD build` *(fails: R not installed)*