### PR TITLE
Implement embed schema defaults

### DIFF
--- a/R/utils_defaults.R
+++ b/R/utils_defaults.R
@@ -152,3 +152,11 @@ lna_default.quant <- function() {
 lna_default.basis <- function() {
   default_params("basis")
 }
+
+#' Default parameters for the 'embed' transform
+#'
+#' Convenience wrapper around `default_params("embed")`.
+#' @export
+lna_default.embed <- function() {
+  default_params("embed")
+}

--- a/inst/schemas/embed.schema.json
+++ b/inst/schemas/embed.schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Parameters for 'embed' transform",
+  "type": "object",
+  "properties": {
+    "basis_path": {"type": "string", "default": ""},
+    "center_data_with": {"type": ["string", "null"], "default": null},
+    "scale_data_with": {"type": ["string", "null"], "default": null}
+  },
+  "additionalProperties": false
+}

--- a/tests/testthat/test-transform_embed.R
+++ b/tests/testthat/test-transform_embed.R
@@ -1,0 +1,12 @@
+library(testthat)
+library(neuroarchive)
+
+
+test_that("default_params for embed loads schema", {
+  cache_env <- get(".default_param_cache", envir = asNamespace("neuroarchive"))
+  rm(list = ls(envir = cache_env), envir = cache_env)
+  p <- neuroarchive:::default_params("embed")
+  expect_equal(p$basis_path, "")
+  expect_null(p$center_data_with)
+  expect_null(p$scale_data_with)
+})


### PR DESCRIPTION
## Summary
- add schema and defaults for the `embed` transform
- expose `lna_default.embed` helper
- test embed default parameter loading

## Testing
- `devtools::test()` *(fails: R not installed)*