### PR TITLE
Implement parallel write safety docs

### DIFF
--- a/R/api.R
+++ b/R/api.R
@@ -15,6 +15,10 @@
 #' @param header Optional named list of header attributes.
 #' @return Invisibly returns a list with elements `file`, `plan`, and
 #'   `header` with class `"lna_write_result"`.
+#' @details For parallel workflows use a unique temporary file and
+#'   `file.rename()` it to the final path once writing succeeds.
+#'   The underlying HDF5 handle is opened with mode `"w"` which
+#'   truncates any existing file at `file`.
 #' @export
 write_lna <- function(x, file = NULL, transforms = character(),
                       transform_params = list(), mask = NULL,

--- a/R/utils_hdf5.R
+++ b/R/utils_hdf5.R
@@ -213,6 +213,9 @@ h5_write_dataset <- function(h5_group, path, data,
 #' @param mode File mode passed to `H5File$new`.
 #' @param ... Additional arguments forwarded to `H5File$new`.
 #' @return An `H5File` object.
+#' @details When `mode` is `"w"` the file is truncated if it already
+#'   exists. Use a unique temporary file and `file.rename()` when
+#'   writing in parallel.
 #' @keywords internal
 open_h5 <- function(path, mode = "r", ...) {
   stopifnot(is.character(path), length(path) == 1)

--- a/README.md
+++ b/README.md
@@ -40,9 +40,11 @@ Later sources override earlier ones using a deep merge.
 
 ### Parallel Writing
 
-For concurrent writers the target file should be written to a unique
-temporary location and atomically renamed once the write succeeds to
-avoid collisions.
+`write_lna()` opens files using HDF5 mode `"w"`, which truncates the
+target path if it already exists.  When writing in parallel each writer
+should therefore create a unique temporary file and use
+`file.rename()` to atomically move it into place after a successful
+write.  This avoids collisions between concurrent writers.
 
 See `vignettes/cookbook.Rmd` for additional examples including ROI/time
 slicing with the lazy reader and scaffolding new transforms.

--- a/tests/testthat/test-write_lna_parallel.R
+++ b/tests/testthat/test-write_lna_parallel.R
@@ -1,0 +1,21 @@
+library(testthat)
+library(withr)
+
+# Test recommended atomic rename pattern for parallel writes
+
+test_that("write_lna temp file can be atomically renamed", {
+  dir <- local_tempdir()
+  final <- file.path(dir, "dest.lna.h5")
+  tmp <- tempfile(tmpdir = dir, fileext = ".h5")
+
+  res <- write_lna(x = 1, file = tmp, transforms = character(0))
+  expect_true(file.exists(tmp))
+  expect_true(file.rename(tmp, final))
+  expect_false(file.exists(tmp))
+  expect_true(file.exists(final))
+
+  h5 <- neuroarchive:::open_h5(final, mode = "r")
+  root <- h5[["/"]]
+  expect_identical(h5_attr_read(root, "lna_spec"), "LNA R v2.0")
+  neuroarchive:::close_h5_safely(h5)
+})


### PR DESCRIPTION
## Summary
- document safe parallel writing in README and write_lna docs
- note truncation behaviour in `open_h5`
- add integration test for atomic rename pattern

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*