### PR TITLE
Implement M2-10 fork safety docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,7 @@ avoid collisions.
 
 See `vignettes/cookbook.Rmd` for additional examples including ROI/time
 slicing with the lazy reader and scaffolding new transforms.
+
+### Validation and Fork Safety
+
+`validate_lna()` uses cached compiled JSON schemas. When running validation inside forked workers (e.g., with `future::plan(multicore)`), clear this cache in each worker using `lna:::schema_cache_clear()` to avoid potential fork-safety issues.

--- a/man/validate_lna.Rd
+++ b/man/validate_lna.Rd
@@ -12,6 +12,11 @@ validate_lna(file, strict = TRUE, checksum = TRUE)
 \value{\code{TRUE} if validation succeeds.}
 \description{Checks the file version and, when requested, verifies the
 stored checksum and transform descriptors.}
+\details{Validation caches compiled JSON schemas for speed. When running
+in forked processes (for example with \code{future::plan(multicore)}),
+these cached objects may not be fork-safe. Clear the cache inside each
+worker with \code{lna:::schema_cache_clear()} before calling
+\code{validate_lna()}.}
 \examples{
 validate_lna("ex.h5")
 }

--- a/tests/testthat/test-validate_fork_safety.R
+++ b/tests/testthat/test-validate_fork_safety.R
@@ -1,0 +1,37 @@
+library(testthat)
+library(hdf5r)
+library(withr)
+
+create_valid_lna <- function(path, checksum = TRUE) {
+  h5 <- neuroarchive:::open_h5(path, mode = "w")
+  plan <- Plan$new()
+  plan$add_descriptor("00_dummy.json", list(type = "dummy"))
+  plan$add_payload("payload", matrix(1:4, nrow = 2))
+  plan$add_dataset_def("/scans/run-01/data", "data", "dummy", "run-01", 0L, "{}",
+                      "payload", "eager")
+  materialise_plan(h5, plan, checksum = if (checksum) "sha256" else "none")
+}
+
+
+
+#' validate_lna works in a forked worker when the schema cache is cleared
+#'
+#' This test uses the future package with multicore plan. The worker clears the
+#' internal schema cache before calling validate_lna. We expect validation to
+#' succeed and return TRUE.
+
+skip_if_not_installed("future")
+skip_on_cran()
+
+test_that("validate_lna works with schema_cache_clear in forked worker", {
+  tmp <- local_tempfile(fileext = ".h5")
+  create_valid_lna(tmp)
+  future::plan("multicore")
+  on.exit(future::plan("sequential"))
+  fut <- future::future({
+    library(neuroarchive)
+    schema_cache_clear()
+    validate_lna(tmp)
+  })
+  expect_true(future::value(fut))
+})


### PR DESCRIPTION
## Summary
- document fork-safety of the schema cache in README and validate_lna man page
- add integration test that clears the schema cache in a forked worker

## Testing
- `R -q -e "testthat::test_dir('tests/testthat')"` *(fails: R not installed)*