### PR TITLE
Implement M2-11 validate_lna schema checks

### DIFF
--- a/inst/schemas/embed.schema.json
+++ b/inst/schemas/embed.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Parameters for 'embed' transform",
+  "type": "object",
+  "properties": {
+    "basis_path": {"type": "string"},
+    "center_data_with": {"type": ["string", "null"], "default": null},
+    "scale_data_with": {"type": ["string", "null"], "default": null}
+  },
+  "required": ["basis_path"],
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary
- add schema file for `embed` transform
- improve `validate_lna` to require schemas and report missing ones
- extend tests to verify schema validation of `basis` and `embed` descriptors

## Testing
- `R CMD check` *(fails: R not installed)*