### PR TITLE
Handle reduced PCA components

### DIFF
--- a/R/transform_basis.R
+++ b/R/transform_basis.R
@@ -83,7 +83,17 @@ forward_step.basis <- function(type, desc, handle) {
   } else {
     fit <- stats::prcomp(X, rank. = k, center = center, scale. = scale)
   }
-  rotation <- fit$rotation[, seq_len(k), drop = FALSE]
+
+  k_effective <- ncol(fit$rotation)
+  if (k_effective < k) {
+    warning(sprintf(
+      "Requested k=%d but fit returned %d components; truncating",
+      k, k_effective
+    ), call. = FALSE)
+  }
+  k_effective <- min(k, k_effective)
+  rotation <- fit$rotation[, seq_len(k_effective), drop = FALSE]
+  p$k <- k_effective
   mean_vec <- if (isTRUE(center)) fit$center else NULL
   scale_vec <- if (isTRUE(scale)) fit$scale else NULL
 
@@ -98,6 +108,7 @@ forward_step.basis <- function(type, desc, handle) {
   center_path <- paste0("/basis/", base_name, "/center")
   scale_path <- paste0("/basis/", base_name, "/scale")
   params_json <- jsonlite::toJSON(p, auto_unbox = TRUE)
+  desc$params <- p
 
   desc$version <- "1.0"
   desc$inputs <- c(input_key)

--- a/tests/testthat/test-transform_basis.R
+++ b/tests/testthat/test-transform_basis.R
@@ -11,3 +11,20 @@ test_that("default_params for basis loads schema", {
   expect_true(p$center)
   expect_false(p$scale)
 })
+
+
+test_that("forward_step.basis truncates k when PCA returns fewer components", {
+  plan <- Plan$new()
+  X <- matrix(rnorm(10), nrow = 2)
+  handle <- DataHandle$new(initial_stash = list(input = X), plan = plan)
+  desc <- list(type = "basis", params = list(k = 5), inputs = c("input"))
+  expect_warning(
+    h <- forward_step.basis("basis", desc, handle),
+    "truncating"
+  )
+  defs <- h$plan$datasets
+  params <- jsonlite::fromJSON(defs$params_json)
+  expect_equal(params$k, 2)
+  payload <- h$plan$payloads[[defs$payload_key]]
+  expect_equal(nrow(payload), params$k)
+})


### PR DESCRIPTION
## Summary
- check how many components PCA returns
- warn and truncate `k` if the fit has fewer columns
- store the effective `k` in descriptor metadata
- test truncation behaviour

## Testing
- `R CMD build .` *(fails: command not found)*
- `Rscript -e "testthat::test_dir('tests/testthat')"` *(fails: command not found)*