### PR TITLE
Implement validate_lna strict mode

### DIFF
--- a/man/validate_lna.Rd
+++ b/man/validate_lna.Rd
@@ -6,10 +6,12 @@ validate_lna(file, strict = TRUE, checksum = TRUE)
 }
 \arguments{
   \item{file}{Path to the file to validate.}
-  \item{strict}{If \code{TRUE} validation errors abort.}
+  \item{strict}{If \code{TRUE} validation errors abort. If \code{FALSE}, all
+  issues are collected and returned.}
   \item{checksum}{If \code{TRUE} verify the stored SHA256 checksum.}
 }
-\value{\code{TRUE} if validation succeeds.}
+\value{\code{TRUE} if validation succeeds. When \code{strict = FALSE} and
+problems are found, a character vector of issue messages is returned instead.}
 \description{Checks the file version and, when requested, verifies the
 stored checksum and transform descriptors.}
 \details{Validation caches compiled JSON schemas for speed. When running

--- a/tests/testthat/test-validate_lna.R
+++ b/tests/testthat/test-validate_lna.R
@@ -70,3 +70,29 @@ test_that("validate_lna fails on invalid descriptor", {
   materialise_plan(h5, plan, checksum = "none")
   expect_error(validate_lna(tmp), class = "lna_error_validation")
 })
+
+test_that("validate_lna strict=FALSE collects multiple issues", {
+  tmp <- local_tempfile(fileext = ".h5")
+  create_valid_lna(tmp)
+  h5 <- neuroarchive:::open_h5(tmp, mode = "r+")
+  root <- h5[["/"]]
+  h5_attr_write(root, "lna_spec", "wrong")
+  h5_attr_write(root, "lna_checksum", "bogus")
+  neuroarchive:::close_h5_safely(h5)
+
+  res <- validate_lna(tmp, strict = FALSE)
+  expect_type(res, "character")
+  expect_length(res, 2)
+})
+
+test_that("validate_lna strict=TRUE errors on first issue", {
+  tmp <- local_tempfile(fileext = ".h5")
+  create_valid_lna(tmp)
+  h5 <- neuroarchive:::open_h5(tmp, mode = "r+")
+  root <- h5[["/"]]
+  h5_attr_write(root, "lna_spec", "wrong")
+  h5_attr_write(root, "lna_checksum", "bogus")
+  neuroarchive:::close_h5_safely(h5)
+
+  expect_error(validate_lna(tmp, strict = TRUE), class = "lna_error_validation")
+})


### PR DESCRIPTION
## Summary
- enhance validate_lna strict mode to collect multiple issues when `strict = FALSE`
- document the new behaviour
- add tests for strict mode

## Testing
- `R -q -e 'devtools::test()'` *(fails: R not installed)*