### PR TITLE
Implement M2-13 block_table support

### DIFF
--- a/R/api.R
+++ b/R/api.R
@@ -13,6 +13,9 @@
 #' @param transform_params Named list of transform parameters.
 #' @param mask Optional mask passed to `core_write`.
 #' @param header Optional named list of header attributes.
+#' @param block_table Optional data frame specifying spatial block coordinates
+#'   stored at `/spatial/block_table`. Coordinate columns must contain
+#'   1-based voxel indices in masked space when a mask is provided.
 #' @return Invisibly returns a list with elements `file`, `plan`, and
 #'   `header` with class `"lna_write_result"`.
 #' @details For parallel workflows use a unique temporary file and
@@ -22,7 +25,7 @@
 #' @export
 write_lna <- function(x, file = NULL, transforms = character(),
                       transform_params = list(), mask = NULL,
-                      header = NULL) {
+                      header = NULL, block_table = NULL) {
   in_memory <- FALSE
   if (is.null(file)) {
     tmp <- tempfile(fileext = ".h5")
@@ -34,12 +37,52 @@ write_lna <- function(x, file = NULL, transforms = character(),
                        transform_params = transform_params,
                        mask = mask, header = header)
 
+  if (!is.null(block_table)) {
+    if (!is.data.frame(block_table)) {
+      abort_lna(
+        "block_table must be a data frame",
+        .subclass = "lna_error_validation",
+        location = "write_lna:block_table"
+      )
+    }
+    if (nrow(block_table) > 0) {
+      num_cols <- vapply(block_table, is.numeric, logical(1))
+      if (!all(num_cols)) {
+        abort_lna(
+          "block_table columns must be numeric",
+          .subclass = "lna_error_validation",
+          location = "write_lna:block_table"
+        )
+      }
+      coords <- unlist(block_table)
+      if (any(coords < 1)) {
+        abort_lna(
+          "block_table coordinates must be >= 1",
+          .subclass = "lna_error_validation",
+          location = "write_lna:block_table"
+        )
+      }
+      max_idx <- result$handle$mask_info$active_voxels
+      if (!is.null(max_idx) && any(coords > max_idx)) {
+        abort_lna(
+          "block_table coordinates exceed masked voxel count",
+          .subclass = "lna_error_validation",
+          location = "write_lna:block_table"
+        )
+      }
+    }
+  }
+
   if (in_memory) {
     h5 <- open_h5(file, mode = "w", driver = "core", backing_store = FALSE)
   } else {
     h5 <- open_h5(file, mode = "w")
   }
   materialise_plan(h5, result$plan, header = result$handle$meta$header)
+
+  if (!is.null(block_table)) {
+    h5_write_dataset(h5[["/"]], "spatial/block_table", as.matrix(block_table))
+  }
   close_h5_safely(h5)
 
   out_file <- if (in_memory) NULL else file

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -85,3 +85,28 @@ test_that("read_lna lazy=TRUE keeps file open", {
   expect_true(handle$h5$is_valid())
   neuroarchive:::close_h5_safely(handle$h5)
 })
+
+test_that("write_lna writes block_table dataset", {
+  tmp <- local_tempfile(fileext = ".h5")
+  arr <- array(1, dim = c(1, 1, 1))
+  msk <- array(TRUE, dim = c(1, 1, 1))
+  bt <- data.frame(start = 1L, end = 1L)
+  write_lna(x = arr, file = tmp, transforms = character(0), mask = msk,
+            block_table = bt)
+  h5 <- neuroarchive:::open_h5(tmp, mode = "r")
+  expect_true(h5$exists("spatial/block_table"))
+  val <- h5[["spatial/block_table"]]$read()
+  expect_equal(val, as.matrix(bt))
+  neuroarchive:::close_h5_safely(h5)
+})
+
+test_that("write_lna validates block_table ranges", {
+  arr <- array(1, dim = c(1, 1, 1))
+  msk <- array(TRUE, dim = c(1, 1, 1))
+  bt_bad <- data.frame(idx = 2L)
+  expect_error(
+    write_lna(x = arr, file = tempfile(fileext = ".h5"),
+              transforms = character(0), mask = msk, block_table = bt_bad),
+    class = "lna_error_validation"
+  )
+})


### PR DESCRIPTION
## Summary
- add `block_table` argument to `write_lna`
- validate and write block tables to `/spatial/block_table`
- test writing and validating `block_table`

## Testing
- `R -q -e 'devtools::test()'` *(fails: command not found)*