### PR TITLE
Implement plugins arg stub for write_lna

### DIFF
--- a/R/api.R
+++ b/R/api.R
@@ -13,6 +13,7 @@
 #' @param transform_params Named list of transform parameters.
 #' @param mask Optional mask passed to `core_write`.
 #' @param header Optional named list of header attributes.
+#' @param plugins Optional named list saved under `/plugins/`.
 #' @return Invisibly returns a list with elements `file`, `plan`, and
 #'   `header` with class `"lna_write_result"`.
 #' @details For parallel workflows use a unique temporary file and
@@ -22,7 +23,7 @@
 #' @export
 write_lna <- function(x, file = NULL, transforms = character(),
                       transform_params = list(), mask = NULL,
-                      header = NULL) {
+                      header = NULL, plugins = NULL) {
   in_memory <- FALSE
   if (is.null(file)) {
     tmp <- tempfile(fileext = ".h5")
@@ -32,14 +33,16 @@ write_lna <- function(x, file = NULL, transforms = character(),
 
   result <- core_write(x = x, transforms = transforms,
                        transform_params = transform_params,
-                       mask = mask, header = header)
+                       mask = mask, header = header, plugins = plugins)
 
   if (in_memory) {
     h5 <- open_h5(file, mode = "w", driver = "core", backing_store = FALSE)
   } else {
     h5 <- open_h5(file, mode = "w")
   }
-  materialise_plan(h5, result$plan, header = result$handle$meta$header)
+  materialise_plan(h5, result$plan,
+                   header = result$handle$meta$header,
+                   plugins = result$handle$meta$plugins)
   close_h5_safely(h5)
 
   out_file <- if (in_memory) NULL else file

--- a/R/core_write.R
+++ b/R/core_write.R
@@ -8,11 +8,13 @@
 #' @param transform_params Named list of user supplied parameters for transforms.
 #' @param mask Optional mask object passed through to transforms.
 #' @param header Optional named list of header attributes.
+#' @param plugins Optional named list of plugin metadata to store under
+#'   `/plugins`.
 #'
 #' @return A list with `handle` and `plan` objects.
 #' @keywords internal
 core_write <- function(x, transforms, transform_params = list(),
-                       mask = NULL, header = NULL) {
+                       mask = NULL, header = NULL, plugins = NULL) {
   stopifnot(is.character(transforms))
   stopifnot(is.list(transform_params))
 
@@ -45,6 +47,20 @@ core_write <- function(x, transforms, transform_params = list(),
     header_list <- header
   } else {
     header_list <- list()
+  }
+
+  if (!is.null(plugins)) {
+    stopifnot(is.list(plugins))
+    if (is.null(names(plugins)) || any(names(plugins) == "")) {
+      abort_lna(
+        "plugins must be a named list",
+        .subclass = "lna_error_validation",
+        location = "core_write:plugins"
+      )
+    }
+    plugin_list <- plugins
+  } else {
+    plugin_list <- list()
   }
 
   # --- Determine run identifiers ---
@@ -87,7 +103,8 @@ core_write <- function(x, transforms, transform_params = list(),
   plan <- Plan$new()
   handle <- DataHandle$new(
     initial_stash = list(input = x),
-    initial_meta = list(mask = mask_array, header = header_list),
+    initial_meta = list(mask = mask_array, header = header_list,
+                        plugins = plugin_list),
     plan = plan,
     run_ids = run_ids,
     current_run_id = run_ids[1],

--- a/man/write_lna.Rd
+++ b/man/write_lna.Rd
@@ -3,7 +3,8 @@
 \title{Write data to an LNA file}
 \usage{
 write_lna(x, file = NULL, transforms = character(),
-          transform_params = list(), mask = NULL, header = NULL)
+          transform_params = list(), mask = NULL, header = NULL,
+          plugins = NULL)
 }
 \arguments{
   \item{x}{Input object passed to \code{core_write}.}
@@ -12,6 +13,7 @@ write_lna(x, file = NULL, transforms = character(),
   \item{transform_params}{Named list of transform parameters.}
   \item{mask}{Optional mask passed to \code{core_write}.}
   \item{header}{Optional named list of header attributes.}
+  \item{plugins}{Optional named list saved to the \code{/plugins} group.}
 }
 \value{Invisibly returns a list with the output file and plan.}
 \description{Compresses and stores a neuroimaging object using the


### PR DESCRIPTION
## Summary
- add `plugins` argument to `write_lna`, `core_write`, and `materialise_plan`
- store plugin metadata in DataHandle and write JSON descriptors under `/plugins`
- document new parameter in man page
- test that `plugins` are forwarded and written correctly

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*