### PR TITLE
Implement run_id globbing

### DIFF
--- a/R/api.R
+++ b/R/api.R
@@ -56,6 +56,8 @@ write_lna <- function(x, file = NULL, transforms = character(),
 #' the HDF5 handle open for on-demand reconstruction of the data.
 #'
 #' @param file Path to an LNA file on disk.
+#' @param run_id Character vector of run identifiers or glob patterns. Passed to
+#'   `core_read` for selection of specific runs.
 #' @param allow_plugins Character string specifying how to handle
 #'   transforms that require optional packages. One of
 #'   \code{"installed"} (default), \code{"none"}, or \code{"prompt"}.
@@ -66,9 +68,11 @@ write_lna <- function(x, file = NULL, transforms = character(),
 #'   `"float32"`, `"float64"`, or `"float16"`.
 #' @param lazy Logical. If `TRUE`, the HDF5 file remains open and the
 #'   returned `lna_reader` can load data lazily.
-#' @return A `DataHandle` object from `core_read`.
+#' @return The result of `core_read`: a `DataHandle` for a single run or a list
+#'   of `DataHandle` objects when multiple runs are loaded.
 #' @export
-read_lna <- function(file, allow_plugins = c("installed", "none", "prompt"),
+read_lna <- function(file, run_id = NULL,
+                     allow_plugins = c("installed", "none", "prompt"),
                      validate = FALSE,
                      output_dtype = c("float32", "float64", "float16"),
                      lazy = FALSE) {
@@ -79,6 +83,7 @@ read_lna <- function(file, allow_plugins = c("installed", "none", "prompt"),
     lna_reader$new(
       file = file,
       core_read_args = list(
+        run_id = run_id,
         allow_plugins = allow_plugins,
         validate = validate,
         output_dtype = output_dtype
@@ -87,6 +92,7 @@ read_lna <- function(file, allow_plugins = c("installed", "none", "prompt"),
   } else {
     core_read(
       file = file,
+      run_id = run_id,
       allow_plugins = allow_plugins,
       validate = validate,
       output_dtype = output_dtype,

--- a/R/reader.R
+++ b/R/reader.R
@@ -26,6 +26,10 @@ lna_reader <- R6::R6Class("lna_reader",
     h5 = NULL,
     #' @field core_args List of arguments forwarded to `core_read`
     core_args = NULL,
+    #' @field run_ids Selected run identifiers
+    run_ids = NULL,
+    #' @field current_run_id Run identifier currently used
+    current_run_id = NULL,
     #' @field subset_params Stored subsetting parameters
     subset_params = NULL,
     #' @field data_cache Cached DataHandle from `$data()`
@@ -43,6 +47,17 @@ lna_reader <- R6::R6Class("lna_reader",
       self$core_args <- core_read_args
       self$subset_params <- list()
       self$h5 <- open_h5(file, mode = "r")
+      runs_avail <- discover_run_ids(self$h5)
+      runs <- resolve_run_ids(core_read_args$run_id, runs_avail)
+      if (length(runs) == 0) {
+        abort_lna("run_id did not match any runs", .subclass = "lna_error_run_id")
+      }
+      if (length(runs) > 1) {
+        warning("Multiple runs matched; using first match for lazy reader")
+        runs <- runs[1]
+      }
+      self$run_ids <- runs
+      self$current_run_id <- runs[1]
     },
 
     #' @description
@@ -65,7 +80,7 @@ lna_reader <- R6::R6Class("lna_reader",
     #' Print summary of the reader
     print = function(...) {
       status <- if (!is.null(self$h5) && self$h5$is_valid()) "open" else "closed"
-      cat("<lna_reader>", self$file, "[", status, "]\n")
+      cat("<lna_reader>", self$file, "[", status, "] runs:", paste(self$run_ids, collapse = ","), "\n")
       invisible(self)
     },
 
@@ -96,7 +111,12 @@ lna_reader <- R6::R6Class("lna_reader",
       }
 
       h5 <- self$h5
-      handle <- DataHandle$new(h5 = h5, subset = params)
+      handle <- DataHandle$new(
+        h5 = h5,
+        subset = params,
+        run_ids = self$run_ids,
+        current_run_id = self$current_run_id
+      )
       tf_group <- h5[["transforms"]]
       transforms <- discover_transforms(tf_group)
       if (nrow(transforms) > 0) {

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -61,18 +61,19 @@ test_that("write_lna forwards arguments to core_write and materialise_plan", {
 test_that("read_lna forwards arguments to core_read", {
   captured <- list()
   with_mocked_bindings(
-    core_read = function(file, allow_plugins, validate, output_dtype, lazy) {
-      captured$core <- list(file = file, allow_plugins = allow_plugins,
+    core_read = function(file, run_id, allow_plugins, validate, output_dtype, lazy) {
+      captured$core <- list(file = file, run_id = run_id, allow_plugins = allow_plugins,
                             validate = validate, output_dtype = output_dtype,
                             lazy = lazy)
       DataHandle$new()
     }, {
-      read_lna("somefile.h5", allow_plugins = "prompt", validate = TRUE,
+      read_lna("somefile.h5", run_id = "run-*", allow_plugins = "prompt", validate = TRUE,
                output_dtype = "float64", lazy = TRUE)
     }
   )
 
   expect_equal(captured$core$file, "somefile.h5")
+  expect_equal(captured$core$run_id, "run-*")
   expect_equal(captured$core$allow_plugins, "prompt")
   expect_true(captured$core$validate)
   expect_equal(captured$core$output_dtype, "float64")

--- a/tests/testthat/test-core_read.R
+++ b/tests/testthat/test-core_read.R
@@ -117,3 +117,58 @@ test_that("core_read allow_plugins='prompt' falls back when non-interactive", {
                     "Missing invert_step") }
   )
 })
+
+test_that("core_read run_id globbing returns handles", {
+  tmp <- local_tempfile(fileext = ".h5")
+  h5 <- neuroarchive:::open_h5(tmp, mode = "w")
+  plan <- Plan$new()
+  plan$add_descriptor("00_dummy.json", list(type = "dummy"))
+  plan$add_payload("p1", 1L)
+  plan$add_dataset_def("/scans/run-01/data", "data", "dummy", "run-01", 0L, "{}", "p1", "eager")
+  plan$add_payload("p2", 2L)
+  plan$add_dataset_def("/scans/run-02/data", "data", "dummy", "run-02", 0L, "{}", "p2", "eager")
+  materialise_plan(h5, plan)
+  neuroarchive:::close_h5_safely(h5)
+
+  with_mocked_bindings(
+    invert_step.dummy = function(type, desc, handle) {
+      path <- paste0("/scans/", handle$current_run_id, "/data")
+      root <- handle$h5[["/"]]
+      val <- h5_read(root, path)
+      handle$update_stash(keys = character(), new_values = list(input = val))
+    }, {
+      res <- core_read(tmp, run_id = "run-0*")
+    }
+  )
+  expect_true(is.list(res))
+  expect_equal(names(res), c("run-01", "run-02"))
+  expect_equal(res[["run-01"]]$stash$input, 1)
+  expect_equal(res[["run-02"]]$stash$input, 2)
+})
+
+test_that("core_read run_id globbing lazy returns first", {
+  tmp <- local_tempfile(fileext = ".h5")
+  h5 <- neuroarchive:::open_h5(tmp, mode = "w")
+  plan <- Plan$new()
+  plan$add_descriptor("00_dummy.json", list(type = "dummy"))
+  plan$add_payload("p1", 1L)
+  plan$add_dataset_def("/scans/run-01/data", "data", "dummy", "run-01", 0L, "{}", "p1", "eager")
+  plan$add_payload("p2", 2L)
+  plan$add_dataset_def("/scans/run-02/data", "data", "dummy", "run-02", 0L, "{}", "p2", "eager")
+  materialise_plan(h5, plan)
+  neuroarchive:::close_h5_safely(h5)
+
+  with_mocked_bindings(
+    invert_step.dummy = function(type, desc, handle) {
+      path <- paste0("/scans/", handle$current_run_id, "/data")
+      root <- handle$h5[["/"]]
+      val <- h5_read(root, path)
+      handle$update_stash(keys = character(), new_values = list(input = val))
+    }, {
+      expect_warning(h <- core_read(tmp, run_id = "run-*", lazy = TRUE), "first match")
+    }
+  )
+  expect_s3_class(h, "DataHandle")
+  expect_equal(h$current_run_id, "run-01")
+  neuroarchive:::close_h5_safely(h$h5)
+})


### PR DESCRIPTION
## Summary
- support `run_id` globbing in `core_read` and `read_lna`
- expose run information through `lna_reader`
- utilities `discover_run_ids()` and `resolve_run_ids()`
- add tests for new behaviour and update API tests

## Testing
- `R` tests *(failed: command not found)*