### PR TITLE
Implement alias functions compress_fmri and open_lna

### DIFF
--- a/R/api.R
+++ b/R/api.R
@@ -94,3 +94,21 @@ read_lna <- function(file, allow_plugins = c("installed", "none", "prompt"),
     )
   }
 }
+
+#' Convenience alias for `write_lna`
+#'
+#' `compress_fmri()` simply forwards its arguments to `write_lna()`.
+#'
+#' @inheritParams write_lna
+#' @seealso write_lna
+#' @export
+compress_fmri <- function(...) write_lna(...)
+
+#' Convenience alias for `read_lna`
+#'
+#' `open_lna()` simply forwards its arguments to `read_lna()`.
+#'
+#' @inheritParams read_lna
+#' @seealso read_lna
+#' @export
+open_lna <- read_lna

--- a/man/compress_fmri.Rd
+++ b/man/compress_fmri.Rd
@@ -1,0 +1,8 @@
+\name{compress_fmri}
+\alias{compress_fmri}
+\title{Convenience alias for write_lna}
+\usage{
+compress_fmri(...)
+}
+\description{Calls \code{\link{write_lna}} with the supplied arguments.}
+\seealso{\code{\link{write_lna}}}

--- a/man/open_lna.Rd
+++ b/man/open_lna.Rd
@@ -1,0 +1,8 @@
+\name{open_lna}
+\alias{open_lna}
+\title{Convenience alias for read_lna}
+\usage{
+open_lna(...)
+}
+\description{Calls \code{\link{read_lna}} with the supplied arguments.}
+\seealso{\code{\link{read_lna}}}

--- a/tests/testthat/test-aliases.R
+++ b/tests/testthat/test-aliases.R
@@ -1,0 +1,29 @@
+library(testthat)
+
+# Tests for convenience alias functions
+
+test_that("compress_fmri forwards to write_lna", {
+  captured <- NULL
+  with_mocked_bindings(
+    write_lna = function(...) { captured <<- list(...); "res" },
+    {
+      out <- compress_fmri(x = 1, file = "foo.h5")
+    }
+  )
+  expect_identical(captured$x, 1)
+  expect_identical(captured$file, "foo.h5")
+  expect_identical(out, "res")
+})
+
+test_that("open_lna forwards to read_lna", {
+  captured <- NULL
+  with_mocked_bindings(
+    read_lna = function(...) { captured <<- list(...); "out" },
+    {
+      res <- open_lna(file = "bar.h5", lazy = TRUE)
+    }
+  )
+  expect_identical(captured$file, "bar.h5")
+  expect_true(captured$lazy)
+  expect_identical(res, "out")
+})


### PR DESCRIPTION
## Summary
- expose convenience wrappers for `write_lna` and `read_lna`
- document the new aliases
- add tests verifying argument forwarding

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*