### PR TITLE
Implement M2-18 integration tests with embed transform

### DIFF
--- a/R/transform_basis.R
+++ b/R/transform_basis.R
@@ -126,5 +126,6 @@ forward_step.basis <- function(type, desc, handle) {
   }
 
   handle$plan <- plan
-  handle$update_stash(keys = input_key, new_values = list())
+  # keep input in the stash for subsequent transforms (e.g., 'embed')
+  handle
 }

--- a/R/transform_embed.R
+++ b/R/transform_embed.R
@@ -1,0 +1,100 @@
+#' Embed Transform - Forward Step
+#'
+#' Projects data onto a pre-computed basis matrix.
+#' @keywords internal
+forward_step.embed <- function(type, desc, handle) {
+  p <- desc$params %||% list()
+  basis_path <- p$basis_path %||% ""
+  if (!nzchar(basis_path)) {
+    abort_lna("'basis_path' is required", .subclass = "lna_error_validation",
+              location = "forward_step.embed:basis_path")
+  }
+  plan <- handle$plan
+  basis <- plan$payloads[[basis_path]]
+  if (is.null(basis)) {
+    abort_lna("basis matrix not found in plan payloads",
+              .subclass = "lna_error_contract",
+              location = "forward_step.embed:basis")
+  }
+  mean_vec <- if (!is.null(p$center_data_with)) plan$payloads[[p$center_data_with]] else NULL
+  scale_vec <- if (!is.null(p$scale_data_with)) plan$payloads[[p$scale_data_with]] else NULL
+
+  input_key <- if (!is.null(desc$inputs)) desc$inputs[[1]] else "input"
+  X <- handle$get_inputs(input_key)[[1]]
+  if (is.array(X) && length(dim(X)) > 2) {
+    d <- dim(X)
+    tdim <- d[length(d)]
+    vdim <- prod(d[-length(d)])
+    X <- matrix(as.numeric(aperm(X, c(length(d), seq_len(length(d) - 1)))),
+                nrow = tdim, ncol = vdim)
+  } else {
+    X <- as.matrix(X)
+  }
+  if (!is.null(mean_vec)) X <- sweep(X, 2, mean_vec, "-")
+  if (!is.null(scale_vec)) X <- sweep(X, 2, scale_vec, "/")
+
+  if (ncol(basis) == ncol(X)) {
+    coeff <- X %*% basis
+  } else {
+    coeff <- X %*% t(basis)
+  }
+
+  run_id <- handle$current_run_id %||% "run-01"
+  fname <- plan$get_next_filename(type)
+  base_name <- tools::file_path_sans_ext(fname)
+  coef_path <- paste0("/scans/", run_id, "/", base_name, "/coefficients")
+  step_index <- plan$next_index
+  params_json <- jsonlite::toJSON(p, auto_unbox = TRUE)
+
+  desc$version <- "1.0"
+  desc$inputs <- c(input_key)
+  desc$outputs <- c("coefficients")
+  desc$datasets <- list(list(path = coef_path, role = "coefficients"))
+
+  plan$add_descriptor(fname, desc)
+  plan$add_payload(coef_path, coeff)
+  plan$add_dataset_def(coef_path, "coefficients", type, run_id,
+                       as.integer(step_index), params_json,
+                       coef_path, "eager")
+
+  handle$plan <- plan
+  handle$update_stash(keys = input_key, new_values = list(input = coeff,
+                                                         coefficients = coeff))
+}
+
+#' Embed Transform - Inverse Step
+#'
+#' Reconstruct data from coefficients using a stored basis.
+#' @keywords internal
+invert_step.embed <- function(type, desc, handle) {
+  p <- desc$params %||% list()
+  basis_path <- p$basis_path %||% ""
+  if (!nzchar(basis_path)) {
+    abort_lna("'basis_path' missing in descriptor",
+              .subclass = "lna_error_descriptor",
+              location = "invert_step.embed")
+  }
+  root <- handle$h5[["/"]]
+  basis <- h5_read(root, basis_path)
+  mean_vec <- if (!is.null(p$center_data_with)) h5_read(root, p$center_data_with) else NULL
+  scale_vec <- if (!is.null(p$scale_data_with)) h5_read(root, p$scale_data_with) else NULL
+
+  coeff_key <- desc$outputs[[1]] %||% "coefficients"
+  output_key <- desc$inputs[[1]] %||% "input"
+
+  if (!handle$exists(coeff_key)) {
+    return(handle)
+  }
+  coeff <- handle$get_inputs(coeff_key)[[coeff_key]]
+
+  if (ncol(basis) == nrow(coeff)) {
+    X <- coeff %*% basis
+  } else {
+    X <- coeff %*% t(basis)
+  }
+  if (!is.null(scale_vec)) X <- sweep(X, 2, scale_vec, "*")
+  if (!is.null(mean_vec)) X <- sweep(X, 2, mean_vec, "+")
+
+  handle$update_stash(keys = coeff_key,
+                      new_values = setNames(list(X), output_key))
+}

--- a/tests/testthat/test-integration_multi_transform.R
+++ b/tests/testthat/test-integration_multi_transform.R
@@ -1,0 +1,54 @@
+library(testthat)
+library(neuroarchive)
+library(withr)
+
+
+test_that("basis -> embed -> quant pipeline roundtrip", {
+  arr <- array(runif(40), dim = c(2,2,2,5))
+  tmp <- local_tempfile(fileext = ".h5")
+
+  res <- write_lna(arr, file = tmp,
+                   transforms = c("basis", "embed", "quant"),
+                   transform_params = list(
+                     embed = list(basis_path = "/basis/00_basis/matrix",
+                                   center_data_with = "/basis/00_basis/center")
+                   ))
+  expect_true(file.exists(tmp))
+
+  h <- read_lna(tmp)
+  out <- h$stash$input
+  expect_equal(dim(out), dim(arr))
+  expect_lt(mean(abs(out - arr)), 1)
+})
+
+
+test_that("quant only pipeline roundtrip", {
+  arr <- array(runif(12), dim = c(3,4))
+  tmp <- local_tempfile(fileext = ".h5")
+
+  res <- write_lna(arr, file = tmp, transforms = "quant")
+  expect_true(file.exists(tmp))
+
+  h <- read_lna(tmp)
+  out <- h$stash$input
+  expect_equal(dim(out), dim(arr))
+  expect_lt(mean(abs(out - arr)), 1)
+})
+
+
+test_that("lna_reader works for multi-transform pipeline", {
+  arr <- array(runif(40), dim = c(2,2,2,5))
+  tmp <- local_tempfile(fileext = ".h5")
+
+  res <- write_lna(arr, file = tmp,
+                   transforms = c("basis", "embed", "quant"),
+                   transform_params = list(
+                     embed = list(basis_path = "/basis/00_basis/matrix",
+                                   center_data_with = "/basis/00_basis/center")
+                   ))
+
+  reader <- read_lna(tmp, lazy = TRUE)
+  out <- reader$data()$stash$input
+  expect_equal(dim(out), dim(arr))
+  reader$close()
+})


### PR DESCRIPTION
## Summary
- keep input data in basis forward step
- implement embed transform forward and inverse steps
- add integration tests for multi-transform pipelines

## Testing
- `R CMD check` *(fails: R not installed)*