### PR TITLE
Add on.exit cleanup for write_h5 handle

### DIFF
--- a/R/api.R
+++ b/R/api.R
@@ -81,6 +81,8 @@ write_lna <- function(x, file = NULL, transforms = character(),
     h5 <- open_h5(file, mode = "w")
   }
 
+  on.exit(close_h5_safely(h5))
+
   materialise_plan(h5, result$plan,
                    header = result$handle$meta$header,
                    plugins = result$handle$meta$plugins)


### PR DESCRIPTION
## Summary
- ensure that write_lna closes the HDF5 handle on error

## Testing
- `R` command not found, so tests could not be run