### PR TITLE
Fix write_lna in-memory doc

### DIFF
--- a/R/api.R
+++ b/R/api.R
@@ -8,7 +8,8 @@
 #'
 #' @param x Input object passed to `core_write`.
 #' @param file Path to output `.h5` file. If `NULL`, writing is performed
-#'   in memory and the file is returned as a raw vector.
+#'   in memory using the HDF5 core driver and no file is created. The
+#'   returned list then has `file = NULL`.
 #' @param transforms Character vector of transform types.
 #' @param transform_params Named list of transform parameters.
 #' @param mask Optional mask passed to `core_write`.

--- a/man/write_lna.Rd
+++ b/man/write_lna.Rd
@@ -8,7 +8,9 @@ write_lna(x, file = NULL, transforms = character(),
 }
 \arguments{
   \item{x}{Input object passed to \code{core_write}.}
-  \item{file}{Path to output file. If \code{NULL}, writing occurs in memory.}
+  \item{file}{Path to output \code{.h5} file. If \code{NULL}, writing is
+    performed in memory using the HDF5 core driver and no file is created.
+    The returned list then contains \code{file = NULL}.}
   \item{transforms}{Character vector of transform types.}
   \item{transform_params}{Named list of transform parameters.}
   \item{mask}{Optional mask passed to \code{core_write}.}


### PR DESCRIPTION
## Summary
- clarify in-memory write behavior in `write_lna`
- sync `man/write_lna.Rd` with updated roxygen comment

## Testing
- `Rscript -e 'cat("Testing")'` *(fails: command not found)*