### PR TITLE
Check basis_path for embed

### DIFF
--- a/R/transform_embed.R
+++ b/R/transform_embed.R
@@ -5,10 +5,13 @@
 #' @keywords internal
 forward_step.embed <- function(type, desc, handle) {
   p <- desc$params %||% list()
-  basis_path <- p$basis_path %||% ""
-  if (!nzchar(basis_path)) {
-    abort_lna("'basis_path' is required", .subclass = "lna_error_validation",
-              location = "forward_step.embed:basis_path")
+  basis_path <- p$basis_path
+  if (is.null(basis_path) || !nzchar(basis_path)) {
+    abort_lna(
+      "'basis_path' must be provided",
+      .subclass = "lna_error_validation",
+      location = "forward_step.embed:basis_path"
+    )
   }
   plan <- handle$plan
   basis <- plan$payloads[[basis_path]]

--- a/tests/testthat/test-transform_embed.R
+++ b/tests/testthat/test-transform_embed.R
@@ -11,6 +11,15 @@ test_that("default_params for embed loads schema", {
   expect_null(p$scale_data_with)
 })
 
+test_that("embed transform errors when basis_path missing", {
+  X <- matrix(rnorm(10), nrow = 5)
+  expect_error(
+    core_write(X, transforms = "embed"),
+    class = "lna_error_validation",
+    regexp = "basis_path"
+  )
+})
+
 
 test_that("embed transform forward computes coefficients", {
   set.seed(1)


### PR DESCRIPTION
## Summary
- validate `basis_path` in `forward_step.embed`
- test for missing `basis_path` error

## Testing
- `R -q -e 'devtools::test()'` *(fails: `R: command not found`)*