### PR TITLE
Implement temporal defaults schema

### DIFF
--- a/R/utils_defaults.R
+++ b/R/utils_defaults.R
@@ -160,3 +160,11 @@ lna_default.basis <- function() {
 lna_default.embed <- function() {
   default_params("embed")
 }
+
+#' Default parameters for the 'temporal' transform
+#'
+#' Convenience wrapper around `default_params("temporal")`.
+#' @export
+lna_default.temporal <- function() {
+  default_params("temporal")
+}

--- a/inst/schemas/temporal.schema.json
+++ b/inst/schemas/temporal.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Parameters for 'temporal' transform",
+  "type": "object",
+  "properties": {
+    "kind": {"type": "string", "enum": ["dct", "bspline", "dpss", "polynomial"], "default": "dct"},
+    "n_basis": {"type": "integer", "minimum": 1, "default": 20},
+    "order": {"type": "integer", "minimum": 1, "default": 3},
+    "knot_vector_path": {"type": "string", "default": ""},
+    "knot_spacing_method": {"type": "string", "enum": ["equidistant", "quantile"], "default": "equidistant"},
+    "time_bandwidth_product": {"type": "number", "default": 3.0},
+    "n_tapers": {"type": "integer", "minimum": 1, "default": 1},
+    "scope": {"type": "string", "enum": ["global", "voxelwise"], "default": "global"}
+  },
+  "additionalProperties": false
+}

--- a/tests/testthat/test-transform_temporal.R
+++ b/tests/testthat/test-transform_temporal.R
@@ -1,0 +1,12 @@
+library(testthat)
+library(neuroarchive)
+
+
+test_that("default_params for temporal loads schema", {
+  cache_env <- get(".default_param_cache", envir = asNamespace("neuroarchive"))
+  rm(list = ls(envir = cache_env), envir = cache_env)
+  p <- neuroarchive:::default_params("temporal")
+  expect_equal(p$kind, "dct")
+  expect_equal(p$scope, "global")
+  expect_true(is.numeric(p$n_basis))
+})


### PR DESCRIPTION
## Summary
- add `temporal.schema.json` with default parameters
- expose `lna_default.temporal()`
- test default params loading for temporal transform

## Testing
- `R -q -e 'devtools::test()'` *(fails: `R` not found)*