### PR TITLE
Implement delta transform defaults

### DIFF
--- a/R/utils_defaults.R
+++ b/R/utils_defaults.R
@@ -160,3 +160,11 @@ lna_default.basis <- function() {
 lna_default.embed <- function() {
   default_params("embed")
 }
+
+#' Default parameters for the 'delta' transform
+#'
+#' Convenience wrapper around `default_params("delta")`.
+#' @export
+lna_default.delta <- function() {
+  default_params("delta")
+}

--- a/inst/schemas/delta.schema.json
+++ b/inst/schemas/delta.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Parameters for 'delta' transform",
+  "type": "object",
+  "properties": {
+    "order": {"type": "integer", "minimum": 1, "default": 1},
+    "axis": {"type": "integer", "minimum": 1, "default": 4},
+    "reference_value_storage": {
+      "type": "string",
+      "enum": ["first_value_verbatim", "reconstruct_from_deltas"],
+      "default": "first_value_verbatim"
+    },
+    "delta_quantization_bits": {
+      "type": ["integer", "null"],
+      "minimum": 1,
+      "maximum": 16,
+      "default": null
+    },
+    "coding_method": {
+      "type": "string",
+      "enum": ["none", "rle", "range_coded"],
+      "default": "none"
+    }
+  },
+  "additionalProperties": false
+}

--- a/tests/testthat/test-transform_delta.R
+++ b/tests/testthat/test-transform_delta.R
@@ -1,0 +1,14 @@
+library(testthat)
+library(neuroarchive)
+
+
+test_that("default_params for delta loads schema", {
+  cache_env <- get(".default_param_cache", envir = asNamespace("neuroarchive"))
+  rm(list = ls(envir = cache_env), envir = cache_env)
+  p <- neuroarchive:::default_params("delta")
+  expect_equal(p$order, 1)
+  expect_equal(p$axis, 4)
+  expect_equal(p$reference_value_storage, "first_value_verbatim")
+  expect_null(p$delta_quantization_bits)
+  expect_equal(p$coding_method, "none")
+})


### PR DESCRIPTION
## Summary
- add `delta.schema.json` with parameter defaults
- expose `lna_default.delta()` wrapper
- test that default params for delta load correctly

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*