### PR TITLE
Implement plugin transform discovery

### DIFF
--- a/R/validate.R
+++ b/R/validate.R
@@ -66,13 +66,21 @@ validate_lna <- function(file, strict = TRUE, checksum = TRUE) {
     for (nm in tf_names) {
       desc <- read_json_descriptor(tf_group, nm)
       if (is.list(desc) && !is.null(desc$type)) {
-        schema_path <- system.file(
-          "schemas",
-          paste0(desc$type, ".schema.json"),
-          package = utils::packageName()
-        )
+        pkgs <- unique(c("neuroarchive", loadedNamespaces()))
+        schema_path <- ""
+        for (pkg in pkgs) {
+          path <- system.file(
+            "schemas",
+            paste0(desc$type, ".schema.json"),
+            package = pkg
+          )
+          if (nzchar(path) && file.exists(path)) {
+            schema_path <- path
+            break
+          }
+        }
 
-        if (!nzchar(schema_path) || !file.exists(schema_path)) {
+        if (!nzchar(schema_path)) {
           fail(sprintf("Schema for transform '%s' not found", desc$type))
           next
         }

--- a/tests/testthat/test-plugin_discovery.R
+++ b/tests/testthat/test-plugin_discovery.R
@@ -1,0 +1,33 @@
+library(testthat)
+library(withr)
+
+# Ensure caches cleared between tests
+teardown({
+  cache_env <- get(".default_param_cache", envir = asNamespace("neuroarchive"))
+  rm(list = ls(envir = cache_env), envir = cache_env)
+  schema_env <- get(".schema_cache", envir = asNamespace("neuroarchive"))
+  rm(list = ls(envir = schema_env), envir = schema_env)
+})
+
+skip_if_not_installed("pkgload")
+
+# Create a temporary plugin package with a schema
+local_tempdir <- withr::local_tempdir()
+pkg_dir <- file.path(local_tempdir, "plugpkg")
+dir.create(file.path(pkg_dir, "R"), recursive = TRUE)
+dir.create(file.path(pkg_dir, "inst", "schemas"), recursive = TRUE)
+
+writeLines("Package: plugpkg\nVersion: 0.0.1\n", file.path(pkg_dir, "DESCRIPTION"))
+writeLines("S3method(forward_step,plug)\nS3method(invert_step,plug)\nexport(forward_step.plug)\nexport(invert_step.plug)", file.path(pkg_dir, "NAMESPACE"))
+
+writeLines("forward_step.plug <- function(type, desc, handle) handle\ninvert_step.plug <- function(type, desc, handle) handle", file.path(pkg_dir, "R", "plug.R"))
+writeLines('{"type":"object","properties":{"foo":{"type":"integer","default":5}}}', file.path(pkg_dir, "inst", "schemas", "plug.schema.json"))
+
+pkgload::load_all(pkg_dir, quiet = TRUE)
+on.exit(unloadNamespace("plugpkg"), add = TRUE)
+
+defaults <- neuroarchive:::default_params("plug")
+
+test_that("default_params finds schema in loaded plugin", {
+  expect_equal(defaults, list(foo = 5L))
+})


### PR DESCRIPTION
## Summary
- support loading transform schemas from any loaded package
- validate transforms using schemas from loaded packages
- add regression test for plugin schema discovery

## Testing
- `R -q -e "testthat::test_dir('tests/testthat')"` *(fails: command not found)*