### PR TITLE
Implement myorg.sparsepca example transform

### DIFF
--- a/R/transform_sparsepca.R
+++ b/R/transform_sparsepca.R
@@ -1,0 +1,101 @@
+#' Sparse PCA Transform - Forward Step
+#'
+#' Performs a very simple sparse PCA using a truncated SVD as a stand in for
+#' a real sparse PCA algorithm. This example demonstrates how an external
+#' plugin transform might integrate with the LNA pipeline.
+#' @keywords internal
+forward_step.myorg.sparsepca <- function(type, desc, handle) {
+  p <- desc$params %||% list()
+  k <- p$k %||% 2
+  alpha <- p$alpha %||% 0.001
+  storage_order <- p$storage_order %||% "component_x_voxel"
+
+  input_key <- if (handle$exists("aggregated_matrix")) "aggregated_matrix" else "dense_mat"
+  X <- handle$get_inputs(input_key)[[1]]
+  if (!is.matrix(X)) {
+    X <- as.matrix(X)
+  }
+
+  if (requireNamespace("irlba", quietly = TRUE)) {
+    fit <- irlba::irlba(X, nv = as.integer(k))
+    basis <- fit$v
+    embed <- fit$u %*% diag(fit$d)
+  } else {
+    sv <- svd(X, nu = as.integer(k), nv = as.integer(k))
+    basis <- sv$v
+    embed <- sv$u %*% diag(sv$d[seq_len(k)])
+  }
+
+  if (identical(storage_order, "voxel_x_component")) {
+    basis <- Matrix::t(basis)
+  }
+
+  plan <- handle$plan
+  fname <- plan$get_next_filename(type)
+  base <- tools::file_path_sans_ext(fname)
+  basis_path <- paste0("/basis/", base, "/basis")
+  embed_path <- paste0("/scans/", handle$current_run_id %||% "run-01",
+                        "/", base, "/embedding")
+  params_json <- jsonlite::toJSON(p, auto_unbox = TRUE)
+
+  desc$version <- "1.0"
+  desc$inputs <- c(input_key)
+  desc$outputs <- c("sparsepca_basis", "sparsepca_embedding")
+  desc$datasets <- list(list(path = basis_path, role = "basis_matrix"),
+                        list(path = embed_path, role = "coefficients"))
+  plan$add_descriptor(fname, desc)
+
+  plan$add_payload(basis_path, basis)
+  plan$add_dataset_def(basis_path, "basis_matrix", type,
+                       handle$plan$origin_label, as.integer(plan$next_index - 1),
+                       params_json, basis_path, "eager")
+  plan$add_payload(embed_path, embed)
+  plan$add_dataset_def(embed_path, "coefficients", type,
+                       handle$plan$origin_label, as.integer(plan$next_index - 1),
+                       params_json, embed_path, "eager")
+
+  handle$plan <- plan
+  out <- list(sparsepca_basis = TRUE, sparsepca_embedding = TRUE)
+  handle <- handle$update_stash(c(input_key), out)
+  handle
+}
+
+#' Sparse PCA Transform - Inverse Step
+#'
+#' Reconstructs data from the sparse PCA coefficients and basis matrix.
+#' @keywords internal
+invert_step.myorg.sparsepca <- function(type, desc, handle) {
+  ds <- desc$datasets
+  basis_path <- ds[[which(vapply(ds, function(d) d$role, character(1)) == "basis_matrix")]]$path
+  embed_path <- ds[[which(vapply(ds, function(d) d$role, character(1)) == "coefficients")]]$path
+
+  root <- handle$h5[["/"]]
+  basis <- h5_read(root, basis_path)
+  embed <- h5_read(root, embed_path)
+  p <- desc$params %||% list()
+  storage_order <- p$storage_order %||% "component_x_voxel"
+  if (identical(storage_order, "voxel_x_component")) {
+    basis <- Matrix::t(basis)
+  }
+
+  Xhat <- embed %*% basis
+  subset <- handle$subset
+  if (!is.null(subset$roi_mask)) {
+    vox_idx <- which(as.logical(subset$roi_mask))
+    Xhat <- Xhat[, vox_idx, drop = FALSE]
+  }
+  if (!is.null(subset$time_idx)) {
+    Xhat <- Xhat[subset$time_idx, , drop = FALSE]
+  }
+
+  output_key <- desc$inputs[[1]] %||% "dense_mat"
+  handle$update_stash(keys = character(),
+                      new_values = setNames(list(Xhat), output_key))
+}
+
+#' Default parameters for myorg.sparsepca
+#' @export
+#' @keywords internal
+lna_default.myorg.sparsepca <- function() {
+  list(k = 50L, alpha = 1e-3, whiten = FALSE, storage_order = "component_x_voxel")
+}

--- a/inst/schemas/myorg.sparsepca.schema.json
+++ b/inst/schemas/myorg.sparsepca.schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://my-lab.org/schemas/lna/2.0/myorg.sparsepca.schema.json",
+  "title": "Parameters for 'myorg.sparsepca' transform",
+  "type": "object",
+  "properties": {
+    "k": {"type": "integer", "minimum": 1, "default": 50},
+    "alpha": {"type": "number", "default": 0.001},
+    "whiten": {"type": "boolean", "default": false},
+    "storage_order": {
+      "type": "string",
+      "enum": ["component_x_voxel", "voxel_x_component"],
+      "default": "component_x_voxel"
+    }
+  },
+  "required": ["k"],
+  "additionalProperties": false
+}

--- a/tests/testthat/test-transform_sparsepca.R
+++ b/tests/testthat/test-transform_sparsepca.R
@@ -1,0 +1,28 @@
+library(testthat)
+library(neuroarchive)
+library(withr)
+
+
+test_that("default_params for myorg.sparsepca loads schema", {
+  cache_env <- get(".default_param_cache", envir = asNamespace("neuroarchive"))
+  rm(list = ls(envir = cache_env), envir = cache_env)
+  p <- neuroarchive:::default_params("myorg.sparsepca")
+  expect_equal(p$k, 50)
+  expect_equal(p$alpha, 0.001)
+  expect_identical(p$whiten, FALSE)
+  expect_equal(p$storage_order, "component_x_voxel")
+})
+
+
+test_that("sparsepca forward and inverse roundtrip", {
+  set.seed(1)
+  X <- matrix(rnorm(40), nrow = 10, ncol = 4)
+  tmp <- local_tempfile(fileext = ".h5")
+
+  write_lna(X, file = tmp, transforms = "myorg.sparsepca",
+            transform_params = list(`myorg.sparsepca` = list(k = 4)))
+  h <- read_lna(tmp)
+  out <- h$stash$input
+  expect_equal(dim(out), dim(X))
+  expect_equal(out, X, tolerance = 1e-6)
+})


### PR DESCRIPTION
## Summary
- add `myorg.sparsepca` schema
- implement `forward_step.myorg.sparsepca` and `invert_step.myorg.sparsepca`
- provide defaults helper
- test sparsepca behaviour

## Testing
- `This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`