### PR TITLE
Implement interactive allow_plugins prompt

### DIFF
--- a/R/api.R
+++ b/R/api.R
@@ -114,8 +114,10 @@ write_lna <- function(x, file = NULL, transforms = character(),
 #' @param allow_plugins Character string specifying how to handle
 #'   transforms that require optional packages. One of
 #'   \code{"installed"} (default), \code{"none"}, or \code{"prompt"}.
-#'   See \code{core_read} for details. Non-interactive sessions treat
-#'   \code{"prompt"} the same as \code{"installed"}.
+#'   Non-interactive sessions treat \code{"prompt"} the same as
+#'   \code{"installed"}. Interactive use of \code{"prompt"} will ask
+#'   whether to continue when a transform implementation is missing;
+#'   declining aborts reading.
 #' @param validate Logical flag for validation; forwarded to `core_read`.
 #' @param output_dtype Desired output data type. One of
 #'   `"float32"`, `"float64"`, or `"float16"`.

--- a/R/core_read.R
+++ b/R/core_read.R
@@ -10,9 +10,12 @@
 #'   against available run groups under `/scans`.
 #' @param allow_plugins Character. How to handle transforms requiring
 #'   external packages. One of "installed" (default), "none", or "prompt".
-#'   "none" errors on missing implementations. "installed" warns and
-#'   proceeds if a transform implementation is unavailable. "prompt"
-#'   behaves like "installed" when \code{!rlang::is_interactive()}.
+#'   "installed" attempts to use a transform if its implementation is
+#'   available, issuing a warning when missing. "prompt" in interactive
+#'   sessions asks whether to continue when a transform implementation is
+#'   missing (non-affirmative answers abort). Non-interactive sessions treat
+#'   "prompt" the same as "installed". "none" errors immediately when an
+#'   implementation is missing.
 #' @param validate Logical flag indicating if validation should be
 #'   performed via `validate_lna()` before reading.
 #' @param output_dtype Desired output data type. One of
@@ -79,17 +82,11 @@ core_read <- function(file, run_id = NULL,
       logical(1)
     )
   ]
-  if (length(missing_methods) > 0) {
-    msg <- paste0(
-      "Missing invert_step implementation for transform(s): ",
-      paste(unique(missing_methods), collapse = ", ")
-    )
-    if (identical(allow_plugins, "none")) {
-      abort_lna(msg, .subclass = "lna_error_no_method")
-    } else {
-      warning(msg)
-    }
-  }
+  handle_missing_methods(
+    missing_methods,
+    allow_plugins,
+    location = sprintf("core_read:%s", file)
+  )
 
   process_run <- function(rid) {
     handle <- DataHandle$new(h5 = h5, run_ids = runs, current_run_id = rid)

--- a/R/reader.R
+++ b/R/reader.R
@@ -143,17 +143,11 @@ lna_reader <- R6::R6Class("lna_reader",
             logical(1)
           )
         ]
-        if (length(missing_methods) > 0) {
-          msg <- paste0(
-            "Missing invert_step implementation for transform(s): ",
-            paste(unique(missing_methods), collapse = ", ")
-          )
-          if (identical(allow_plugins, "none")) {
-            abort_lna(msg, .subclass = "lna_error_no_method")
-          } else {
-            warning(msg)
-          }
-        }
+        handle_missing_methods(
+          missing_methods,
+          allow_plugins,
+          location = sprintf("lna_reader:data:%s", self$file)
+        )
       }
       if (nrow(transforms) > 0) {
         for (i in rev(seq_len(nrow(transforms)))) {

--- a/R/utils_transform.R
+++ b/R/utils_transform.R
@@ -29,3 +29,37 @@ check_transform_implementation <- function(type) {
 
   invisible(TRUE)
 }
+
+#' Handle missing transform implementations
+#'
+#' Internal helper used by `core_read` and `lna_reader` to process cases
+#' where a transform's S3 methods are unavailable. Behaviour depends on
+#' the `allow_plugins` mode.
+#'
+#' @param missing_types Character vector of transform types lacking
+#'   implementations.
+#' @param allow_plugins One of "installed", "none", or "prompt".
+#' @param location Optional string used in error conditions.
+#' @keywords internal
+handle_missing_methods <- function(missing_types, allow_plugins, location = NULL) {
+  if (length(missing_types) == 0) return(invisible(NULL))
+
+  msg <- paste0(
+    "Missing invert_step implementation for transform(s): ",
+    paste(unique(missing_types), collapse = ", ")
+  )
+
+  if (identical(allow_plugins, "none")) {
+    abort_lna(msg, .subclass = "lna_error_no_method", location = location)
+  } else if (identical(allow_plugins, "prompt") && rlang::is_interactive()) {
+    response <- tolower(trimws(readline(paste0(msg, " Continue anyway? [y/N]: "))))
+    if (!response %in% c("y", "yes")) {
+      abort_lna(msg, .subclass = "lna_error_no_method", location = location)
+    }
+    warning(msg, call. = FALSE)
+  } else {
+    warning(msg, call. = FALSE)
+  }
+
+  invisible(NULL)
+}

--- a/tests/testthat/test-core_read.R
+++ b/tests/testthat/test-core_read.R
@@ -118,6 +118,24 @@ test_that("core_read allow_plugins='prompt' falls back when non-interactive", {
   )
 })
 
+test_that("core_read allow_plugins='prompt' interactive respects user choice", {
+  tmp <- local_tempfile(fileext = ".h5")
+  create_dummy_lna(tmp)
+  with_mocked_bindings(
+    rlang::is_interactive = function() TRUE,
+    readline = function(prompt = "") "n",
+    { expect_error(core_read(tmp, allow_plugins = "prompt"),
+                  class = "lna_error_no_method") }
+  )
+
+  with_mocked_bindings(
+    rlang::is_interactive = function() TRUE,
+    readline = function(prompt = "") "y",
+    { expect_warning(core_read(tmp, allow_plugins = "prompt"),
+                    "Missing invert_step") }
+  )
+})
+
 
 test_that("core_read stores subset parameters", {
   tmp <- local_tempfile(fileext = ".h5")

--- a/tests/testthat/test-reader.R
+++ b/tests/testthat/test-reader.R
@@ -89,3 +89,23 @@ test_that("lna_reader$data allow_plugins='prompt' falls back when non-interactiv
   )
   reader$close()
 })
+
+test_that("lna_reader$data allow_plugins='prompt' interactive respects choice", {
+  tmp <- local_tempfile(fileext = ".h5")
+  create_dummy_lna(tmp)
+  reader <- read_lna(tmp, lazy = TRUE, allow_plugins = "prompt")
+  with_mocked_bindings(
+    rlang::is_interactive = function() TRUE,
+    readline = function(prompt = "") "n",
+    { expect_error(reader$data(), class = "lna_error_no_method") }
+  )
+  reader$close()
+
+  reader <- read_lna(tmp, lazy = TRUE, allow_plugins = "prompt")
+  with_mocked_bindings(
+    rlang::is_interactive = function() TRUE,
+    readline = function(prompt = "") "y",
+    { expect_warning(reader$data(), "Missing invert_step") }
+  )
+  reader$close()
+})


### PR DESCRIPTION
## Summary
- prompt user when plugin implementations are missing
- centralize missing-plugin handling logic
- document allow_plugins behaviour
- add interactive prompt tests

## Testing
- `R -q -e 'devtools::test()'` *(fails: command not found)*