### PR TITLE
Implement skipping for unknown plugins

### DIFF
--- a/R/api.R
+++ b/R/api.R
@@ -115,9 +115,10 @@ write_lna <- function(x, file = NULL, transforms = character(),
 #'   transforms that require optional packages. One of
 #'   \code{"installed"} (default), \code{"none"}, or \code{"prompt"}.
 #'   Non-interactive sessions treat \code{"prompt"} the same as
-#'   \code{"installed"}. Interactive use of \code{"prompt"} will ask
-#'   whether to continue when a transform implementation is missing;
-#'   declining aborts reading.
+#'   \code{"installed"}.  When a required transform implementation is
+#'   missing, \code{"installed"} emits a warning and skips that
+#'   transform. Interactive use of \code{"prompt"} will ask whether to
+#'   continue; declining aborts reading.
 #' @param validate Logical flag for validation; forwarded to `core_read`.
 #' @param output_dtype Desired output data type. One of
 #'   `"float32"`, `"float64"`, or `"float16"`.

--- a/R/core_read.R
+++ b/R/core_read.R
@@ -82,11 +82,14 @@ core_read <- function(file, run_id = NULL,
       logical(1)
     )
   ]
-  handle_missing_methods(
+  skip_types <- handle_missing_methods(
     missing_methods,
     allow_plugins,
     location = sprintf("core_read:%s", file)
   )
+  if (length(skip_types) > 0) {
+    transforms <- transforms[!transforms$type %in% skip_types, , drop = FALSE]
+  }
 
   process_run <- function(rid) {
     handle <- DataHandle$new(h5 = h5, run_ids = runs, current_run_id = rid)

--- a/R/reader.R
+++ b/R/reader.R
@@ -143,11 +143,14 @@ lna_reader <- R6::R6Class("lna_reader",
             logical(1)
           )
         ]
-        handle_missing_methods(
+        skip_types <- handle_missing_methods(
           missing_methods,
           allow_plugins,
           location = sprintf("lna_reader:data:%s", self$file)
         )
+        if (length(skip_types) > 0) {
+          transforms <- transforms[!transforms$type %in% skip_types, , drop = FALSE]
+        }
       }
       if (nrow(transforms) > 0) {
         for (i in rev(seq_len(nrow(transforms)))) {

--- a/R/utils_transform.R
+++ b/R/utils_transform.R
@@ -42,7 +42,7 @@ check_transform_implementation <- function(type) {
 #' @param location Optional string used in error conditions.
 #' @keywords internal
 handle_missing_methods <- function(missing_types, allow_plugins, location = NULL) {
-  if (length(missing_types) == 0) return(invisible(NULL))
+  if (length(missing_types) == 0) return(character())
 
   msg <- paste0(
     "Missing invert_step implementation for transform(s): ",
@@ -61,5 +61,5 @@ handle_missing_methods <- function(missing_types, allow_plugins, location = NULL
     warning(msg, call. = FALSE)
   }
 
-  invisible(NULL)
+  invisible(missing_types)
 }

--- a/man/read_lna.Rd
+++ b/man/read_lna.Rd
@@ -14,7 +14,9 @@ read_lna(file, run_id = NULL,
   \item{run_id}{Character vector of run identifiers or glob patterns.}
   \item{allow_plugins}{How to handle optional-package transforms.
   One of \code{"installed"} (default), \code{"none"}, or \code{"prompt"}.
-  Non-interactive sessions treat \code{"prompt"} as \code{"installed"}.}
+  Non-interactive sessions treat \code{"prompt"} as \code{"installed"}.
+  Missing implementations are skipped with a warning unless
+  \code{allow_plugins = "none"}.}
   \item{validate}{Logical flag for validation.}
   \item{output_dtype}{Desired output data type.}
   \item{roi_mask}{Optional ROI mask for subsetting.}


### PR DESCRIPTION
## Summary
- return missing types from `handle_missing_methods`
- skip transforms lacking methods in `core_read` and `lna_reader`
- document behaviour of `allow_plugins`

## Testing
- `R -q -e 'devtools::test()'` *(fails: R not installed)*