### PR TITLE
Add DPSS, polynomial and wavelet temporal transforms

### DIFF
--- a/R/transform_temporal.R
+++ b/R/transform_temporal.R
@@ -1,6 +1,6 @@
 #' Temporal Transform - Forward Step
 #'
-#' Projects data onto a temporal basis (DCT or B-spline).
+#' Projects data onto a temporal basis (DCT, B-spline, DPSS, polynomial, or wavelet).
 #' @keywords internal
 forward_step.temporal <- function(type, desc, handle) {
   p <- desc$params %||% list()
@@ -28,6 +28,17 @@ forward_step.temporal <- function(type, desc, handle) {
     basis <- .dct_basis(n_time, n_basis)
   } else if (identical(kind, "bspline")) {
     basis <- .bspline_basis(n_time, n_basis, order)
+  } else if (identical(kind, "dpss")) {
+    nw <- p$time_bandwidth_product %||% 3
+    n_tapers <- p$n_tapers %||% n_basis
+    n_basis <- min(n_basis, n_tapers, n_time)
+    basis <- .dpss_basis(n_time, n_basis, nw)
+  } else if (identical(kind, "polynomial")) {
+    basis <- .polynomial_basis(n_time, n_basis)
+  } else if (identical(kind, "wavelet")) {
+    wavelet_name <- p$wavelet %||% "db4"
+    basis <- .wavelet_basis(n_time, wavelet_name)
+    n_basis <- ncol(basis)
   } else {
     abort_lna(
       sprintf("Unsupported temporal kind '%s'", kind),
@@ -143,4 +154,80 @@ invert_step.temporal <- function(type, desc, handle) {
 .bspline_basis <- function(n_time, n_basis, order) {
   x <- seq_len(n_time)
   splines::bs(x, df = n_basis, degree = order, intercept = TRUE)
+}
+
+#' Generate DPSS basis matrix
+#' @keywords internal
+.dpss_basis <- function(n_time, n_basis, nw) {
+  W <- nw / n_time
+  m <- seq_len(n_time) - 1
+  S <- outer(m, m, function(i, j) {
+    if (i == j) {
+      2 * W
+    } else {
+      sin(2 * pi * W * (i - j)) / (pi * (i - j))
+    }
+  })
+  eig <- eigen(S, symmetric = TRUE)
+  eig$vectors[, seq_len(n_basis), drop = FALSE]
+}
+
+#' Generate orthogonal polynomial basis matrix
+#' @keywords internal
+.polynomial_basis <- function(n_time, n_basis) {
+  degree <- max(n_basis - 1, 0)
+  const <- matrix(rep(1 / sqrt(n_time), n_time), ncol = 1)
+  if (degree > 0) {
+    P <- stats::poly(seq_len(n_time), degree = degree, simple = TRUE)
+    cbind(const, P)
+  } else {
+    const
+  }
+}
+
+#' Generate Daubechies wavelet basis matrix
+#'
+#' Daubechies 4 ("db4") tends to balance temporal resolution and smoothness
+#' for fMRI applications, so it is used as the default.
+#' @keywords internal
+.wavelet_basis <- function(n_time, wavelet = "db4") {
+  if (!identical(wavelet, "db4")) {
+    abort_lna(sprintf("Unsupported wavelet '%s'", wavelet),
+              .subclass = "lna_error_validation",
+              location = ".wavelet_basis")
+  }
+  if (log2(n_time) %% 1 != 0) {
+    abort_lna("wavelet basis requires power-of-two length",
+              .subclass = "lna_error_validation",
+              location = ".wavelet_basis")
+  }
+  h <- c(0.48296291314469025, 0.8365163037378079,
+          0.22414386804201339, -0.12940952255126034)
+  g <- c(-0.12940952255126034, -0.22414386804201339,
+          0.8365163037378079, -0.48296291314469025)
+  L <- length(h)
+  dwt_single <- function(x) {
+    n <- length(x)
+    J <- log2(n)
+    res <- numeric(n)
+    offset <- 0
+    for (level in seq_len(J)) {
+      n_curr <- n / 2^(level - 1)
+      cA <- numeric(n_curr/2)
+      cD <- numeric(n_curr/2)
+      for (k in seq_len(n_curr/2)) {
+        idx <- (2 * k - 1) + seq_len(L) - 1
+        idx <- ((idx - 1) %% n_curr) + 1
+        cA[k] <- sum(h * x[idx])
+        cD[k] <- sum(g * x[idx])
+      }
+      res[(offset + 1):(offset + n_curr/2)] <- cD
+      offset <- offset + n_curr/2
+      x[seq_len(n_curr/2)] <- cA
+    }
+    res[offset + 1] <- x[1]
+    res
+  }
+  I <- diag(n_time)
+  apply(I, 2, dwt_single)
 }

--- a/inst/schemas/temporal.schema.json
+++ b/inst/schemas/temporal.schema.json
@@ -3,13 +3,14 @@
   "title": "Parameters for 'temporal' transform",
   "type": "object",
   "properties": {
-    "kind": {"type": "string", "enum": ["dct", "bspline", "dpss", "polynomial"], "default": "dct"},
+    "kind": {"type": "string", "enum": ["dct", "bspline", "dpss", "polynomial", "wavelet"], "default": "dct"},
     "n_basis": {"type": "integer", "minimum": 1, "default": 20},
     "order": {"type": "integer", "minimum": 1, "default": 3},
     "knot_vector_path": {"type": "string", "default": ""},
     "knot_spacing_method": {"type": "string", "enum": ["equidistant", "quantile"], "default": "equidistant"},
     "time_bandwidth_product": {"type": "number", "default": 3.0},
     "n_tapers": {"type": "integer", "minimum": 1, "default": 1},
+    "wavelet": {"type": "string", "default": "db4"},
     "scope": {"type": "string", "enum": ["global", "voxelwise"], "default": "global"}
   },
   "additionalProperties": false

--- a/tests/testthat/test-transform_temporal.R
+++ b/tests/testthat/test-transform_temporal.R
@@ -55,3 +55,44 @@ test_that("temporal transform bspline roundtrip", {
   expect_equal(dim(out), dim(X))
   expect_equal(out, X, tolerance = 1e-6)
 })
+
+test_that("temporal transform dpss roundtrip", {
+  set.seed(1)
+  X <- matrix(rnorm(64), nrow = 16, ncol = 4)
+  tmp <- local_tempfile(fileext = ".h5")
+  write_lna(X, file = tmp, transforms = "temporal",
+            transform_params = list(temporal = list(kind = "dpss",
+                                                    n_basis = 4,
+                                                    time_bandwidth_product = 3,
+                                                    n_tapers = 4)))
+  h <- read_lna(tmp)
+  out <- h$stash$input
+  expect_equal(dim(out), dim(X))
+  expect_equal(out, X, tolerance = 1e-6)
+})
+
+test_that("temporal transform polynomial roundtrip", {
+  set.seed(1)
+  X <- matrix(rnorm(48), nrow = 12, ncol = 4)
+  tmp <- local_tempfile(fileext = ".h5")
+  write_lna(X, file = tmp, transforms = "temporal",
+            transform_params = list(temporal = list(kind = "polynomial",
+                                                    n_basis = 5)))
+  h <- read_lna(tmp)
+  out <- h$stash$input
+  expect_equal(dim(out), dim(X))
+  expect_equal(out, X, tolerance = 1e-6)
+})
+
+test_that("temporal transform wavelet roundtrip", {
+  set.seed(1)
+  X <- matrix(rnorm(64), nrow = 16, ncol = 4)
+  tmp <- local_tempfile(fileext = ".h5")
+  write_lna(X, file = tmp, transforms = "temporal",
+            transform_params = list(temporal = list(kind = "wavelet",
+                                                    wavelet = "db4")))
+  h <- read_lna(tmp)
+  out <- h$stash$input
+  expect_equal(dim(out), dim(X))
+  expect_equal(out, X, tolerance = 1e-6)
+})


### PR DESCRIPTION
## Summary
- extend `temporal` transform schema with `wavelet` option and default `db4`
- implement DPSS, polynomial and Daubechies wavelet bases in `forward_step.temporal`
- document that db4 is chosen as the default wavelet for fMRI
- add unit tests for the new basis kinds

## Testing
- `R -q -e 'sessionInfo()'` *(fails: `bash: R: command not found`)*