### PR TITLE
Implement Phase3 M3-11 and M3-12 checks

### DIFF
--- a/R/validate.R
+++ b/R/validate.R
@@ -48,6 +48,12 @@ validate_lna <- function(file, strict = TRUE, checksum = TRUE) {
     }
   }
 
+  for (attr_name in c("creator", "required_transforms")) {
+    if (!h5_attr_exists(root, attr_name)) {
+      fail(sprintf("Missing %s attribute", attr_name))
+    }
+  }
+
   if (checksum && h5_attr_exists(root, "lna_checksum")) {
     stored <- h5_attr_read(root, "lna_checksum")
     if (is.character(file) && file.exists(file)) {
@@ -57,6 +63,19 @@ validate_lna <- function(file, strict = TRUE, checksum = TRUE) {
       }
     } else {
       warning("Checksum requested but file path unavailable; skipping")
+    }
+  }
+
+  for (grp in c("transforms", "basis", "scans")) {
+    if (!h5$exists(grp)) {
+      fail(sprintf("Required group '%s' missing", grp))
+    }
+  }
+
+  optional_groups <- c("spatial", "plugins")
+  for (grp in optional_groups) {
+    if (h5$exists(grp)) {
+      NULL  # presence noted but no action; placeholder for future checks
     }
   }
 
@@ -89,6 +108,45 @@ validate_lna <- function(file, strict = TRUE, checksum = TRUE) {
         valid <- jsonvalidate::json_validate(json, schema_path, verbose = TRUE)
         if (!isTRUE(valid)) {
           fail(sprintf("Descriptor %s failed schema validation", nm))
+        }
+
+        if (!is.null(desc$datasets)) {
+          for (ds in desc$datasets) {
+            path <- ds$path
+            if (is.null(path) || !nzchar(path)) next
+            if (!h5$exists(path)) {
+              fail(sprintf("Dataset '%s' referenced in %s missing", path, nm))
+              next
+            }
+
+            dset <- h5[[path]]
+            if (!is.null(ds$dims)) {
+              if (!identical(as.integer(ds$dims), as.integer(dset$dims))) {
+                fail(sprintf("Dimensions mismatch for dataset '%s'", path))
+              }
+            }
+
+            if (!is.null(ds$dtype)) {
+              dt <- dset$get_type()
+              class_id <- dt$get_class()
+              size <- dt$get_size()
+              actual <- switch(as.character(class_id),
+                `1` = paste0(ifelse(dt$get_sign() == "H5T_SGN_NONE", "u", ""),
+                              "int", size * 8),
+                `0` = paste0("float", size * 8),
+                "unknown" )
+              if (!identical(tolower(ds$dtype), actual)) {
+                fail(sprintf("Dtype mismatch for dataset '%s'", path))
+              }
+            }
+
+            data <- tryCatch(h5_read(root, path), error = function(e) NULL)
+            if (is.numeric(data)) {
+              if (all(is.na(data)) || all(data == 0)) {
+                fail(sprintf("Dataset '%s' contains only zeros/NaN", path))
+              }
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary
- enhance `validate_lna()` with checks for required attributes and groups
- verify dataset references, dimensions, dtypes and basic data sanity
- expand unit tests for new validation behaviour

## Testing
- `R` not available in this environment, so tests could not be executed