### PR TITLE
Implement runtime validation in core_read

### DIFF
--- a/R/core_read.R
+++ b/R/core_read.R
@@ -103,6 +103,7 @@ core_read <- function(file, run_id = NULL,
           name <- transforms$name[[i]]
           type <- transforms$type[[i]]
           desc <- read_json_descriptor(tf_group, name)
+          if (validate) runtime_validate_step(type, desc, h5)
           handle <<- invert_step(type, desc, handle)
         }
       }


### PR DESCRIPTION
## Summary
- add required_params caching helper
- add runtime_validate_step and call it from core_read when `validate=TRUE`
- test runtime checks for dataset existence and missing required params

## Testing
- `devtools::test()` *(fails: `bash: R: command not found`)*