### PR TITLE
Implement M3-14 error provenance

### DIFF
--- a/R/core_read.R
+++ b/R/core_read.R
@@ -102,8 +102,9 @@ core_read <- function(file, run_id = NULL,
           if (!is.null(p)) p(message = transforms$type[[i]])
           name <- transforms$name[[i]]
           type <- transforms$type[[i]]
+          step_idx <- transforms$index[[i]]
           desc <- read_json_descriptor(tf_group, name)
-          handle <<- invert_step(type, desc, handle)
+          handle <<- run_transform_step("invert", type, desc, handle, step_idx)
         }
       }
       if (progress_enabled) {

--- a/R/core_write.R
+++ b/R/core_write.R
@@ -122,8 +122,8 @@ core_write <- function(x, transforms, transform_params = list(),
     for (type in transforms) {
       if (!is.null(p)) p(message = type)
       desc <- list(type = type, params = merged_params[[type]])
-      cls <- structure(type, class = c(type, "character"))
-      handle <<- forward_step(cls, desc, handle)
+      step_idx <- handle$plan$next_index
+      handle <<- run_transform_step("forward", type, desc, handle, step_idx)
     }
   }
   if (progress_enabled) {

--- a/R/materialise.R
+++ b/R/materialise.R
@@ -93,7 +93,8 @@ materialise_plan <- function(h5, plan, checksum = c("none", "sha256"),
           path, step_index, conditionMessage(res)
         ),
         .subclass = "lna_error_hdf5_write",
-        location = sprintf("materialise_plan:%s", path)
+        location = sprintf("materialise_plan[%d]:%s", step_index, path),
+        parent = res
       )
     }
   }

--- a/R/utils_error.R
+++ b/R/utils_error.R
@@ -9,8 +9,14 @@
 #' @param .subclass Character string giving the LNA error subclass.
 #' @return No return value. This function always throws an error.
 #' @keywords internal
-abort_lna <- function(message, ..., .subclass, location = NULL) {
+abort_lna <- function(message, ..., .subclass, location = NULL, parent = NULL) {
   stopifnot(is.character(message), length(message) == 1)
-  stopifnot(is.character(.subclass), length(.subclass) == 1)
-  rlang::abort(message, ..., .subclass = .subclass, location = location)
+  stopifnot(is.character(.subclass))
+  rlang::abort(
+    message,
+    ...,
+    .subclass = .subclass,
+    location = location,
+    parent = parent
+  )
 }

--- a/tests/testthat/test-error_provenance.R
+++ b/tests/testthat/test-error_provenance.R
@@ -1,0 +1,35 @@
+library(testthat)
+
+# forward_step error provenance
+
+forward_step.fail <- function(type, desc, handle) {
+  stop("boom")
+}
+assign("forward_step.fail", forward_step.fail, envir = .GlobalEnv)
+withr::defer(rm("forward_step.fail", envir = .GlobalEnv))
+
+test_that("core_write reports step provenance", {
+  err <- expect_error(core_write(x = 1, transforms = "fail"))
+  expect_true(grepl("forward_step.fail\[0\]", err$location))
+})
+
+# invert_step error provenance
+invert_step.fail <- function(type, desc, handle) {
+  stop("oops")
+}
+assign("invert_step.fail", invert_step.fail, envir = .GlobalEnv)
+withr::defer(rm("invert_step.fail", envir = .GlobalEnv))
+
+create_fail_file <- function(path) {
+  h5 <- neuroarchive:::open_h5(path, mode = "w")
+  tf <- h5$create_group("transforms")
+  write_json_descriptor(tf, "00_fail.json", list(type = "fail"))
+  neuroarchive:::close_h5_safely(h5)
+}
+
+test_that("core_read reports step provenance", {
+  tmp <- local_tempfile(fileext = ".h5")
+  create_fail_file(tmp)
+  err <- expect_error(core_read(tmp))
+  expect_true(grepl("invert_step.fail\[0\]", err$location))
+})


### PR DESCRIPTION
## Summary
- improve `abort_lna` to accept parent conditions
- add `run_transform_step` helper to attach step information
- update `core_write`, `core_read` and `materialise_plan` to use new provenance logic
- add regression tests for provenance reporting

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*