### PR TITLE
Implement lna_options defaults

### DIFF
--- a/R/materialise.R
+++ b/R/materialise.R
@@ -46,7 +46,7 @@ materialise_plan <- function(h5, plan, checksum = c("none", "sha256"),
 
   # Helper to write a single payload dataset with retries
   write_payload <- function(path, data, step_index) {
-    comp_level <- lna_options("write.compression")[[1]]
+    comp_level <- lna_options("write.compression_level")[[1]]
     if (is.null(comp_level)) comp_level <- 0
     chunk_dims <- NULL
 

--- a/R/options.R
+++ b/R/options.R
@@ -1,10 +1,17 @@
 #' Package Options for LNA
 #'
-#' Minimal stub implementation storing options in a package environment.
+#' Provides a lightweight mechanism for storing global package defaults.
+#' Options are kept in an internal environment and can be retrieved or
+#' updated via this helper.  Typical options include
+#' `write.compression_level`, `write.chunk_target_mib` and per-transform
+#' defaults such as `quant` or `delta` lists.
 #'
-#' @param ... Named options to set, or names of options to retrieve.
-#' @return A list of current options or requested values.
-#' @keywords internal
+#' @param ... Named options to set, or character names of options to
+#'   retrieve.  If no arguments are provided, the full option list is
+#'   returned.
+#' @return A list of current options or the requested subset.  When setting
+#'   values the updated option list is returned invisibly.
+#' @export
 lna_options <- function(...) {
   .lna_opts <- get(".lna_opts", envir = lna_options_env)
   args <- list(...)
@@ -21,4 +28,11 @@ lna_options <- function(...) {
 }
 
 lna_options_env <- new.env(parent = emptyenv())
-assign(".lna_opts", new.env(parent = emptyenv()), envir = lna_options_env)
+default_opts <- list(
+  write.compression_level = 0L,
+  write.chunk_target_mib = 1,
+  quant = list(),
+  delta = list()
+)
+assign(".lna_opts", list2env(default_opts, parent = emptyenv()),
+       envir = lna_options_env)

--- a/R/utils_hdf5.R
+++ b/R/utils_hdf5.R
@@ -104,7 +104,9 @@ h5_attr_delete <- function(h5_obj, name) {
 #' @param dtype_size Size in bytes of a single data element.
 #' @return Integer vector of chunk dimensions.
 guess_chunk_dims <- function(dims, dtype_size) {
-  target <- 1024^2  # 1 MiB
+  target_mib <- lna_options("write.chunk_target_mib")[[1]]
+  if (is.null(target_mib)) target_mib <- 1
+  target <- as.numeric(target_mib) * 1024^2
   chunk <- hdf5r::guess_chunks(space_maxdims = dims,
                                dtype_size = dtype_size,
                                chunk_size = target)

--- a/tests/testthat/test-options_defaults.R
+++ b/tests/testthat/test-options_defaults.R
@@ -16,8 +16,11 @@ teardown({
 # Test lna_options set/get
 
 test_that("lna_options set and get work", {
-  lna_options(write.compression = 3)
-  expect_equal(lna_options("write.compression")[[1]], 3)
+  lna_options(write.compression_level = 3)
+  expect_equal(lna_options("write.compression_level")[[1]], 3)
+
+  lna_options(write.chunk_target_mib = 2)
+  expect_equal(lna_options("write.chunk_target_mib")[[1]], 2)
 
   lna_options(foo = "bar", baz = 1)
   res <- lna_options("foo", "baz")


### PR DESCRIPTION
## Summary
- expand lna_options with default options and export
- switch to `write.compression_level` option
- make chunk size heuristic configurable with `write.chunk_target_mib`
- update materialise_plan to use new option name
- adjust tests for updated option names

## Testing
- `R -q -e 'devtools::test()'` *(fails: R command not found)*