### PR TITLE
Use real sparsepca implementation when available

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,5 +22,6 @@ Imports:
     withr,
     wavelets
 Suggests:
+    sparsepca,
     testthat (>= 3.0.0)
 Config/testthat/edition: 3


### PR DESCRIPTION
## Summary
- switch sparsepca transform to use `sparsepca::spca()` when installed
- fall back to truncated SVD if the package is unavailable
- note sparsepca in package `Suggests`

## Testing
- `R CMD build .` *(fails: `R` not found)*
- `Rscript -e "print('test')"` *(fails: `Rscript` not found)*