### PR TITLE
Add validation for read_lna file path

### DIFF
--- a/R/api.R
+++ b/R/api.R
@@ -144,6 +144,13 @@ read_lna <- function(file, run_id = NULL,
                      output_dtype = c("float32", "float64", "float16"),
                      roi_mask = NULL, time_idx = NULL,
                      lazy = FALSE) {
+  if (!(is.character(file) && length(file) == 1)) {
+    abort_lna(
+      "file must be a path",
+      .subclass = "lna_error_validation",
+      location = "read_lna:file"
+    )
+  }
   output_dtype <- match.arg(output_dtype)
   allow_plugins <- match.arg(allow_plugins)
 

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -104,6 +104,11 @@ test_that("read_lna lazy=TRUE keeps file open", {
   neuroarchive:::close_h5_safely(handle$h5)
 })
 
+test_that("read_lna validates file argument", {
+  expect_error(read_lna(1), class = "lna_error_validation")
+  expect_error(read_lna(c("a", "b")), class = "lna_error_validation")
+})
+
 test_that("write_lna writes block_table dataset", {
   tmp <- local_tempfile(fileext = ".h5")
   arr <- array(1, dim = c(1, 1, 1))


### PR DESCRIPTION
## Summary
- validate the `file` argument at start of `read_lna`
- raise `lna_error_validation` if `file` is not a scalar character
- test the new validation logic

## Testing
- `devtools::test()` *(fails: R not installed)*