### PR TITLE
Fix transform loop and subset handling in core_read

### DIFF
--- a/R/core_read.R
+++ b/R/core_read.R
@@ -69,8 +69,6 @@ core_read <- function(file, run_id = NULL,
     subset_params$time_idx <- as.integer(time_idx)
   }
 
-  handle <- DataHandle$new(h5 = h5, subset = subset_params)
-
   tf_group <- h5[["transforms"]]
 
   transforms <- discover_transforms(tf_group)
@@ -92,11 +90,16 @@ core_read <- function(file, run_id = NULL,
   }
 
   process_run <- function(rid) {
-    handle <- DataHandle$new(h5 = h5, run_ids = runs, current_run_id = rid)
+    handle <- DataHandle$new(
+      h5 = h5,
+      run_ids = runs,
+      current_run_id = rid,
+      subset = subset_params
+    )
 
     if (nrow(transforms) > 0) {
       progress_enabled <- !progressr::handlers_is_empty()
-      loop <- function() {
+      step_loop <- function(h) {
         p <- if (progress_enabled) progressr::progressor(steps = nrow(transforms)) else NULL
         for (i in rev(seq_len(nrow(transforms)))) {
           if (!is.null(p)) p(message = transforms$type[[i]])
@@ -105,16 +108,15 @@ core_read <- function(file, run_id = NULL,
           step_idx <- transforms$index[[i]]
           desc <- read_json_descriptor(tf_group, name)
 
-          handle <<- run_transform_step("invert", type, desc, handle, step_idx)
+          h <- run_transform_step("invert", type, desc, h, step_idx)
           if (validate) runtime_validate_step(type, desc, h5)
-          handle <<- invert_step(type, desc, handle)
-
         }
+        h
       }
-      if (progress_enabled) {
-        progressr::with_progress(loop())
+      handle <- if (progress_enabled) {
+        progressr::with_progress(step_loop(handle))
       } else {
-        loop()
+        step_loop(handle)
       }
     }
 


### PR DESCRIPTION
## Summary
- fix transform loop to avoid double execution
- pass subset params when constructing DataHandle
- restructure loop to avoid `<<-`

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*