### PR TITLE
Remove debug prints from discover_transforms

### DIFF
--- a/R/discover.R
+++ b/R/discover.R
@@ -20,15 +20,15 @@
 #' @importFrom tibble tibble
 #' @keywords internal
 discover_transforms <- function(h5_group) {
-  print(paste("Input object class:", paste(class(h5_group), collapse=", ")))
   stopifnot(inherits(h5_group, "H5Group"))
 
   obj_names <- tryCatch({
     names(h5_group)
   }, error = function(e) {
-    print("Error occurred during h5_group$names():")
-    print(conditionMessage(e))
-    stop("Failed to list names in HDF5 group.", call. = FALSE)
+    stop(
+      paste0("Failed to list names in HDF5 group: ", conditionMessage(e)),
+      call. = FALSE
+    )
   })
 
   # Handle empty group


### PR DESCRIPTION
## Summary
- clean up `discover_transforms` by removing debug `print()` calls

## Testing
- `Rscript -e 'print("test")'` *(fails: command not found)*