### PR TITLE
Warn on stash overwrite

### DIFF
--- a/R/handle.R
+++ b/R/handle.R
@@ -103,10 +103,17 @@ DataHandle <- R6::R6Class("DataHandle",
          current_stash[keys_to_remove] <- NULL
       }
 
-      # Add new values (potentially overwriting existing keys if not removed)
-      # Consider if overwriting should be prevented/warned if key wasn't in `keys`?
-      # For now, allow overwriting as list assignment does.
+      # Warn if new_values will overwrite existing stash entries that were not removed
       if (length(new_values) > 0) {
+          overlap <- intersect(names(new_values), names(current_stash))
+          if (length(overlap) > 0) {
+              warning(
+                paste(
+                  "Overwriting existing stash entries:",
+                  paste(overlap, collapse = ", ")
+                )
+              )
+          }
           # Use modifyList for safe merging/overwriting
           current_stash <- utils::modifyList(current_stash, new_values)
       }

--- a/tests/testthat/test-handle.R
+++ b/tests/testthat/test-handle.R
@@ -215,4 +215,17 @@ test_that("DataHandle update_stash provides immutability", {
   expect_false(identical(h1, h6)) # But object should be new (due to clone)
   expect_identical(h1$stash, h1_stash) # h1 unchanged
 
-}) 
+})
+
+test_that("DataHandle update_stash warns when overwriting without removal", {
+  h <- DataHandle$new(initial_stash = list(a = 1, b = 2))
+
+  expect_warning(
+    h2 <- h$update_stash(keys = character(0), new_values = list(a = 99)),
+    "Overwriting existing stash entries: a"
+  )
+
+  expect_equal(h2$stash$a, 99)
+  expect_equal(h2$stash$b, 2)
+  expect_identical(h$stash, list(a = 1, b = 2))
+})


### PR DESCRIPTION
## Summary
- warn about overwriting stash values in `update_stash`
- test warning behaviour in `test-handle.R`

## Testing
- `R -q -e 'devtools::test()'` *(fails: command not found)*