### PR TITLE
Fix R6 class lookup

### DIFF
--- a/R/handle.R
+++ b/R/handle.R
@@ -122,7 +122,11 @@ DataHandle <- R6::R6Class("DataHandle",
     with = function(...) {
       new_obj <- self$clone(deep = TRUE) # Use deep clone for safety with lists
       updates <- list(...)
-      allowed_fields <- names(get(class(self)[1])$public_fields)
+      class_def <- self$.__enclos_env__$private$.class
+      if (is.null(class_def)) {
+        class_def <- self$.__enclos_env__$self
+      }
+      allowed_fields <- names(class_def$public_fields)
 
       for (field_name in names(updates)) {
         if (!field_name %in% allowed_fields) {

--- a/tests/testthat/test-handle.R
+++ b/tests/testthat/test-handle.R
@@ -163,6 +163,15 @@ test_that("DataHandle with method provides immutability", {
 
 })
 
+test_that("DataHandle $with works without class in search path", {
+  local_class <- DataHandle
+  h1 <- local_class$new(initial_stash = list(a = 1))
+  rm(DataHandle, envir = environment())
+  on.exit(assign("DataHandle", local_class, envir = environment()))
+  h2 <- h1$with(stash = list(b = 2))
+  expect_identical(h2$stash, list(b = 2))
+})
+
 test_that("DataHandle update_stash provides immutability", {
   # Initial object
   h1_stash <- list(a = 1, b = 2, c = 3)


### PR DESCRIPTION
## Summary
- reference class definition from the object rather than using `get()`
- ensure `$with()` works if the `DataHandle` class isn't globally available

## Testing
- `R CMD check` *(fails: R not installed)*