### PR TITLE
Fix stash type docs

### DIFF
--- a/R/handle.R
+++ b/R/handle.R
@@ -8,7 +8,7 @@
 #' @keywords internal
 DataHandle <- R6::R6Class("DataHandle",
   public = list(
-    #' @field stash A list environment holding temporary data objects during transform chain.
+    #' @field stash A list holding temporary data objects during transform chain.
     stash = NULL,
     #' @field meta A list holding metadata associated with the data.
     meta = NULL,


### PR DESCRIPTION
## Summary
- clarify that `stash` is a list in DataHandle

## Testing
- `R -q -e 'devtools::document()'` *(fails: command not found)*
- `R -q -e 'devtools::test()'` *(fails: command not found)*