### PR TITLE
Improve inversion step provenance

### DIFF
--- a/R/core_read.R
+++ b/R/core_read.R
@@ -107,7 +107,6 @@ core_read <- function(file, run_id = NULL,
 
           handle <<- run_transform_step("invert", type, desc, handle, step_idx)
           if (validate) runtime_validate_step(type, desc, h5)
-          handle <<- invert_step(type, desc, handle)
 
         }
       }

--- a/R/reader.R
+++ b/R/reader.R
@@ -156,8 +156,9 @@ lna_reader <- R6::R6Class("lna_reader",
         for (i in rev(seq_len(nrow(transforms)))) {
           name <- transforms$name[[i]]
           type <- transforms$type[[i]]
+          step_idx <- transforms$index[[i]]
           desc <- read_json_descriptor(tf_group, name)
-          handle <- invert_step(type, desc, handle)
+          handle <- run_transform_step("invert", type, desc, handle, step_idx)
         }
       }
 

--- a/tests/testthat/test-error_provenance.R
+++ b/tests/testthat/test-error_provenance.R
@@ -33,3 +33,22 @@ test_that("core_read reports step provenance", {
   err <- expect_error(core_read(tmp))
   expect_true(grepl("invert_step.fail\[0\]", err$location))
 })
+
+create_double_fail_file <- function(path) {
+  h5 <- neuroarchive:::open_h5(path, mode = "w")
+  tf <- h5$create_group("transforms")
+  write_json_descriptor(tf, "00_dummy.json", list(type = "dummy"))
+  write_json_descriptor(tf, "01_fail.json", list(type = "fail"))
+  neuroarchive:::close_h5_safely(h5)
+}
+
+test_that("core_read error location uses transform index", {
+  tmp <- local_tempfile(fileext = ".h5")
+  create_double_fail_file(tmp)
+  invert_step.dummy <- function(type, desc, handle) handle
+  assign("invert_step.dummy", invert_step.dummy, envir = .GlobalEnv)
+  withr::defer(rm("invert_step.dummy", envir = .GlobalEnv))
+
+  err <- expect_error(core_read(tmp))
+  expect_true(grepl("invert_step.fail\[1\]", err$location))
+})


### PR DESCRIPTION
## Summary
- call `run_transform_step` during inversion in `core_read`
- wrap inversion steps in `lna_reader$data()` with `run_transform_step`
- test error location includes transform index for multi-step inversion

## Testing
- `devtools::test()` *(fails: R not installed)*