### PR TITLE
Clear cache on lna_reader close

### DIFF
--- a/R/reader.R
+++ b/R/reader.R
@@ -79,6 +79,8 @@ lna_reader <- R6::R6Class("lna_reader",
         close_h5_safely(self$h5)
         self$h5 <- NULL
       }
+      self$data_cache <- NULL
+      self$cache_params <- NULL
       invisible(NULL)
     },
 

--- a/tests/testthat/test-reader.R
+++ b/tests/testthat/test-reader.R
@@ -40,6 +40,20 @@ test_that("lna_reader close is idempotent", {
 })
 
 
+test_that("lna_reader close clears caches", {
+  tmp <- local_tempfile(fileext = ".h5")
+  create_empty_lna(tmp)
+
+  reader <- read_lna(tmp, lazy = TRUE)
+  reader$data()
+  expect_false(is.null(reader$data_cache))
+  expect_false(is.null(reader$cache_params))
+  reader$close()
+  expect_null(reader$data_cache)
+  expect_null(reader$cache_params)
+})
+
+
 test_that("lna_reader data caches result and respects subset", {
   tmp <- local_tempfile(fileext = ".h5")
   create_empty_lna(tmp)


### PR DESCRIPTION
## Summary
- ensure `lna_reader$close()` drops cached data
- test cache fields after `close()`

## Testing
- `R -q -e "devtools::test()"` *(fails: `R: command not found`)*