### PR TITLE
Validate subset parameters in lna_reader

### DIFF
--- a/R/reader.R
+++ b/R/reader.R
@@ -98,12 +98,31 @@ lna_reader <- R6::R6Class("lna_reader",
 
     #' @description
     #' Store subsetting parameters for later `$data()` calls.
+    #' Only `roi_mask` and `time_idx` are accepted.
     #' @param ... Named parameters such as `roi_mask`, `time_idx`
     subset = function(...) {
+      allowed <- c("roi_mask", "time_idx")
       args <- list(...)
       if (length(args) > 0) {
-        self$subset_params <- utils::modifyList(self$subset_params, args,
-                                                keep.null = TRUE)
+        if (is.null(names(args)) || any(names(args) == "")) {
+          abort_lna(
+            "subset parameters must be named",
+            .subclass = "lna_error_validation",
+            location = "lna_reader:subset"
+          )
+        }
+        unknown <- setdiff(names(args), allowed)
+        if (length(unknown) > 0) {
+          abort_lna(
+            paste0("Unknown subset parameter(s): ",
+                   paste(unknown, collapse = ", ")),
+            .subclass = "lna_error_validation",
+            location = "lna_reader:subset"
+          )
+        }
+        self$subset_params <- utils::modifyList(
+          self$subset_params, args, keep.null = TRUE
+        )
       }
       invisible(self)
     },

--- a/tests/testthat/test-reader.R
+++ b/tests/testthat/test-reader.R
@@ -71,6 +71,17 @@ test_that("read_lna lazy passes subset params", {
   reader$close()
 })
 
+test_that("lna_reader$subset validates parameters", {
+  tmp <- local_tempfile(fileext = ".h5")
+  create_empty_lna(tmp)
+  reader <- read_lna(tmp, lazy = TRUE)
+
+  expect_error(reader$subset(bad = 1), class = "lna_error_validation")
+  expect_error(reader$subset(1), class = "lna_error_validation")
+
+  reader$close()
+})
+
 test_that("lna_reader$data allow_plugins='none' errors on unknown transform", {
   tmp <- local_tempfile(fileext = ".h5")
   create_dummy_lna(tmp)


### PR DESCRIPTION
## Summary
- validate lna_reader$subset arguments
- add unit tests for invalid subset parameters

## Testing
- `devtools::test()` *(fails: `R` not found)*