### PR TITLE
Handle closed lazy reader

### DIFF
--- a/R/reader.R
+++ b/R/reader.R
@@ -112,12 +112,20 @@ lna_reader <- R6::R6Class("lna_reader",
     #' Load and reconstruct data applying current subsetting.
     #' @param ... Optional subsetting parameters overriding stored ones
     #' @return A `DataHandle` object representing the loaded data
-    data = function(...) {
-      args <- list(...)
-      params <- self$subset_params
-      if (length(args) > 0) {
-        params <- utils::modifyList(params, args, keep.null = TRUE)
-      }
+      data = function(...) {
+        args <- list(...)
+        if (is.null(self$h5) || !self$h5$is_valid()) {
+          abort_lna(
+            "lna_reader is closed",
+            .subclass = "lna_error_closed_reader",
+            location = sprintf("lna_reader:data:%s", self$file)
+          )
+        }
+
+        params <- self$subset_params
+        if (length(args) > 0) {
+          params <- utils::modifyList(params, args, keep.null = TRUE)
+        }
       if (!is.null(self$data_cache) && identical(params, self$cache_params)) {
         return(self$data_cache)
       }

--- a/R/utils_error.R
+++ b/R/utils_error.R
@@ -20,3 +20,8 @@ abort_lna <- function(message, ..., .subclass, location = NULL, parent = NULL) {
     parent = parent
   )
 }
+
+#' Error thrown when `lna_reader` methods are called after the reader is closed.
+#'
+#' @keywords internal
+lna_error_closed_reader <- NULL

--- a/tests/testthat/test-reader.R
+++ b/tests/testthat/test-reader.R
@@ -109,3 +109,11 @@ test_that("lna_reader$data allow_plugins='prompt' interactive respects choice", 
   )
   reader$close()
 })
+
+test_that("lna_reader$data errors when called after close", {
+  tmp <- local_tempfile(fileext = ".h5")
+  create_empty_lna(tmp)
+  reader <- read_lna(tmp, lazy = TRUE)
+  reader$close()
+  expect_error(reader$data(), class = "lna_error_closed_reader")
+})


### PR DESCRIPTION
## Summary
- check if lazy `lna_reader` is closed before using `$data`
- document the `lna_error_closed_reader` condition
- test that calling `$data()` after `$close()` errors

## Testing
- `R -q -e "devtools::test()"` *(fails: `bash: R: command not found`)*