### PR TITLE
Fix invert basis orientation

### DIFF
--- a/R/transform_basis.R
+++ b/R/transform_basis.R
@@ -1,6 +1,11 @@
 #' Basis Transform - Inverse Step
 #'
 #' Reconstructs data from coefficients using a stored basis matrix.
+#'
+#' The `basis` dataset may be stored either as a component-by-voxel matrix
+#' (`storage_order = "component_x_voxel"`) or as a voxel-by-component matrix
+#' (`storage_order = "voxel_x_component"`). After optional transposition, it
+#' should have dimensions `n_voxel x n_component` for reconstruction.
 #' @keywords internal
 invert_step.basis <- function(type, desc, handle) {
   p <- desc$params %||% list()
@@ -45,11 +50,15 @@ invert_step.basis <- function(type, desc, handle) {
     coeff <- coeff[subset$time_idx, , drop = FALSE]
   }
 
-  if (identical(storage_order, "voxel_x_component")) {
+  if (identical(storage_order, "component_x_voxel")) {
     basis <- t(basis)
   }
 
-  dense <- tcrossprod(coeff, basis)
+  if (nrow(basis) == ncol(coeff)) {
+    dense <- coeff %*% basis
+  } else {
+    dense <- coeff %*% t(basis)
+  }
 
   handle$update_stash(keys = coeff_key, new_values = setNames(list(dense), input_key))
 }

--- a/tests/testthat/test-transform_basis_inverse.R
+++ b/tests/testthat/test-transform_basis_inverse.R
@@ -4,50 +4,59 @@ library(neuroarchive)
 library(withr)
 
 
-test_that("invert_step.basis reconstructs dense data", {
-  tmp <- local_tempfile(fileext = ".h5")
-  h5 <- H5File$new(tmp, mode = "w")
-  basis_mat <- matrix(c(1,0,0,1,1,1), nrow = 2)
-  neuroarchive:::h5_write_dataset(h5, "/basis/test/matrix", basis_mat)
-
-  desc <- list(
-    type = "basis",
-    params = list(storage_order = "component_x_voxel"),
-    datasets = list(list(path = "/basis/test/matrix", role = "basis_matrix")),
-    inputs = c("dense_mat"),
-    outputs = c("coef")
-  )
-
+test_that("invert_step.basis reconstructs dense data for both storage orders", {
   coef_mat <- matrix(c(1,2,3,4), nrow = 2)
-  handle <- DataHandle$new(initial_stash = list(coef = coef_mat), h5 = h5)
+  base_mat_cxv <- matrix(c(1,0,0,1,1,1), nrow = 2) # component x voxel
+  base_mat_vxc <- t(base_mat_cxv)                      # voxel x component
 
-  h <- invert_step.basis("basis", desc, handle)
+  for (ord in c("component_x_voxel", "voxel_x_component")) {
+    tmp <- local_tempfile(fileext = ".h5")
+    h5 <- H5File$new(tmp, mode = "w")
+    mat <- if (identical(ord, "component_x_voxel")) base_mat_cxv else base_mat_vxc
+    neuroarchive:::h5_write_dataset(h5, "/basis/test/matrix", mat)
 
-  expect_true(h$exists("dense_mat"))
-  expect_false(h$exists("coef"))
-  expected <- tcrossprod(coef_mat, basis_mat)
-  expect_equal(h$stash$dense_mat, expected)
+    desc <- list(
+      type = "basis",
+      params = list(storage_order = ord),
+      datasets = list(list(path = "/basis/test/matrix", role = "basis_matrix")),
+      inputs = c("dense_mat"),
+      outputs = c("coef")
+    )
 
-  h5$close_all()
+    handle <- DataHandle$new(initial_stash = list(coef = coef_mat), h5 = h5)
+    h <- invert_step.basis("basis", desc, handle)
+    expect_true(h$exists("dense_mat"))
+    expect_false(h$exists("coef"))
+    expected <- if (identical(ord, "component_x_voxel"))
+      coef_mat %*% base_mat_cxv else coef_mat %*% t(base_mat_vxc)
+    expect_equal(h$stash$dense_mat, expected)
+    h5$close_all()
+  }
 })
 
 test_that("invert_step.basis applies subset", {
-  tmp <- local_tempfile(fileext = ".h5")
-  h5 <- H5File$new(tmp, mode = "w")
-  basis_mat <- matrix(c(1,0,0,1,1,1), nrow = 2)
-  neuroarchive:::h5_write_dataset(h5, "/basis/test/matrix", basis_mat)
-  desc <- list(
-    type = "basis",
-    params = list(storage_order = "component_x_voxel"),
-    datasets = list(list(path = "/basis/test/matrix", role = "basis_matrix")),
-    inputs = c("dense_mat"),
-    outputs = c("coef")
-  )
   coef_mat <- matrix(1:6, nrow = 3, ncol = 2)
   subset <- list(roi_mask = c(TRUE, FALSE, TRUE), time_idx = c(1,3))
-  handle <- DataHandle$new(initial_stash = list(coef = coef_mat), h5 = h5, subset = subset)
-  h <- invert_step.basis("basis", desc, handle)
-  expect_equal(dim(h$stash$dense_mat), c(length(subset$time_idx), sum(subset$roi_mask)))
-  h5$close_all()
+  base_mat_cxv <- matrix(c(1,0,0,1,1,1), nrow = 2)
+  base_mat_vxc <- t(base_mat_cxv)
+
+  for (ord in c("component_x_voxel", "voxel_x_component")) {
+    tmp <- local_tempfile(fileext = ".h5")
+    h5 <- H5File$new(tmp, mode = "w")
+    mat <- if (identical(ord, "component_x_voxel")) base_mat_cxv else base_mat_vxc
+    neuroarchive:::h5_write_dataset(h5, "/basis/test/matrix", mat)
+    desc <- list(
+      type = "basis",
+      params = list(storage_order = ord),
+      datasets = list(list(path = "/basis/test/matrix", role = "basis_matrix")),
+      inputs = c("dense_mat"),
+      outputs = c("coef")
+    )
+    handle <- DataHandle$new(initial_stash = list(coef = coef_mat), h5 = h5, subset = subset)
+    h <- invert_step.basis("basis", desc, handle)
+    expect_equal(dim(h$stash$dense_mat),
+                 c(length(subset$time_idx), sum(subset$roi_mask)))
+    h5$close_all()
+  }
 })
 


### PR DESCRIPTION
## Summary
- fix orientation logic in `invert_step.basis`
- handle reconstruction for both storage orders
- test reconstruction for `component_x_voxel` and `voxel_x_component`
- document expected basis dimensions

## Testing
- `R -q -e "print('test')"` *(fails: command not found)*