### PR TITLE
Validate delta coding_method

### DIFF
--- a/R/transform_delta.R
+++ b/R/transform_delta.R
@@ -9,6 +9,13 @@ forward_step.delta <- function(type, desc, handle) {
   axis <- p$axis %||% -1
   ref_store <- p$reference_value_storage %||% "first_value_verbatim"
   coding <- p$coding_method %||% "none"
+  if (!coding %in% c("none", "rle")) {
+    abort_lna(
+      sprintf("Unsupported coding_method '%s'", coding),
+      .subclass = "lna_error_validation",
+      location = "forward_step.delta:coding_method"
+    )
+  }
 
   if (!identical(order, 1L)) {
     abort_lna("only order=1 supported", .subclass = "lna_error_validation",
@@ -83,6 +90,13 @@ invert_step.delta <- function(type, desc, handle) {
   axis <- p$axis %||% -1
   ref_store <- p$reference_value_storage %||% "first_value_verbatim"
   coding <- p$coding_method %||% "none"
+  if (!coding %in% c("none", "rle")) {
+    abort_lna(
+      sprintf("Unsupported coding_method '%s'", coding),
+      .subclass = "lna_error_validation",
+      location = "invert_step.delta:coding_method"
+    )
+  }
   dims <- p$orig_dims
   if (is.null(dims)) {
     abort_lna("orig_dims missing in descriptor", .subclass = "lna_error_descriptor",

--- a/tests/testthat/test-transform_delta.R
+++ b/tests/testthat/test-transform_delta.R
@@ -47,3 +47,15 @@ test_that("delta transform with rle coding works", {
   expect_equal(p$coding_method, "none")
 
 })
+
+test_that("delta transform rejects unsupported coding_method", {
+  arr <- matrix(1:4, nrow = 2)
+  tmp <- local_tempfile(fileext = ".h5")
+
+  expect_error(
+    write_lna(arr, file = tmp, transforms = "delta",
+              transform_params = list(delta = list(coding_method = "bogus"))),
+    class = "lna_error_validation",
+    regexp = "coding_method"
+  )
+})


### PR DESCRIPTION
## Summary
- validate `coding_method` in `forward_step.delta` and `invert_step.delta`
- test unsupported `coding_method` handling

## Testing
- `R` was not available in this environment, so unit tests could not be run.