### PR TITLE
Fix delta rle test param init

### DIFF
--- a/tests/testthat/test-transform_delta.R
+++ b/tests/testthat/test-transform_delta.R
@@ -41,6 +41,8 @@ test_that("delta transform with rle coding works", {
   out <- h$stash$input
   expect_equal(out, arr)
 
+  p <- neuroarchive:::default_params("delta")
+
   expect_equal(p$axis, 4)
   expect_equal(p$reference_value_storage, "first_value_verbatim")
   expect_null(p$delta_quantization_bits)


### PR DESCRIPTION
## Summary
- instantiate default delta params in rle test

## Testing
- `R CMD check .` *(fails: R command not found)*