### PR TITLE
Improve embed transform validation and tests

### DIFF
--- a/R/transform_embed.R
+++ b/R/transform_embed.R
@@ -34,6 +34,13 @@ forward_step.embed <- function(type, desc, handle) {
   } else {
     X <- as.matrix(X)
   }
+  if (!is.numeric(X)) {
+    abort_lna(
+      "embed transform requires numeric input matrix",
+      .subclass = "lna_error_validation",
+      location = "forward_step.embed:input"
+    )
+  }
   if (!is.null(mean_vec)) X <- sweep(X, 2, mean_vec, "-")
   if (!is.null(scale_vec)) X <- sweep(X, 2, scale_vec, "/")
 
@@ -98,9 +105,38 @@ invert_step.embed <- function(type, desc, handle) {
   }
 
   root <- handle$h5[["/"]]
+  if (!root$exists(basis_path)) {
+    abort_lna(
+      sprintf("basis matrix dataset '%s' not found", basis_path),
+      .subclass = "lna_error_contract",
+      location = "invert_step.embed:basis"
+    )
+  }
   basis <- h5_read(root, basis_path)
-  mean_vec <- if (!is.null(p$center_data_with)) h5_read(root, p$center_data_with) else NULL
-  scale_vec <- if (!is.null(p$scale_data_with)) h5_read(root, p$scale_data_with) else NULL
+  if (!is.null(p$center_data_with)) {
+    if (!root$exists(p$center_data_with)) {
+      abort_lna(
+        sprintf("center dataset '%s' not found", p$center_data_with),
+        .subclass = "lna_error_contract",
+        location = "invert_step.embed:center"
+      )
+    }
+    mean_vec <- h5_read(root, p$center_data_with)
+  } else {
+    mean_vec <- NULL
+  }
+  if (!is.null(p$scale_data_with)) {
+    if (!root$exists(p$scale_data_with)) {
+      abort_lna(
+        sprintf("scale dataset '%s' not found", p$scale_data_with),
+        .subclass = "lna_error_contract",
+        location = "invert_step.embed:scale"
+      )
+    }
+    scale_vec <- h5_read(root, p$scale_data_with)
+  } else {
+    scale_vec <- NULL
+  }
 
   coeff <- handle$get_inputs(coeff_key)[[coeff_key]]
 

--- a/tests/testthat/test-transform_embed.R
+++ b/tests/testthat/test-transform_embed.R
@@ -33,3 +33,17 @@ test_that("embed transform forward computes coefficients", {
   coeff <- plan$payloads[[coeff_path]]
   expect_equal(nrow(coeff), nrow(X))
 })
+
+test_that("embed transform requires numeric input", {
+  plan <- Plan$new()
+  h <- DataHandle$new(initial_stash = list(input = matrix("a", nrow = 2)),
+                      plan = plan)
+  plan$add_payload("/basis/mat", diag(2))
+  desc <- list(type = "embed", params = list(basis_path = "/basis/mat"),
+               inputs = c("input"))
+  expect_error(
+    neuroarchive:::forward_step.embed("embed", desc, h),
+    class = "lna_error_validation",
+    regexp = "numeric"
+  )
+})

--- a/tests/testthat/test-transform_embed_inverse.R
+++ b/tests/testthat/test-transform_embed_inverse.R
@@ -47,3 +47,40 @@ test_that("read_lna applies roi_mask and time_idx for embed", {
   expect_equal(dim(out), c(2, sum(roi)))
   expect_equal(out, arr[c(2,4), roi])
 })
+
+test_that("invert_step.embed errors when datasets missing", {
+  tmp <- local_tempfile(fileext = ".h5")
+  h5 <- H5File$new(tmp, mode = "w")
+  desc <- list(type = "embed", params = list(basis_path = "/missing"),
+               inputs = c("dense"), outputs = c("coef"))
+  handle <- DataHandle$new(initial_stash = list(coef = matrix(1)), h5 = h5)
+  expect_error(
+    invert_step.embed("embed", desc, handle),
+    class = "lna_error_contract",
+    regexp = "basis"
+  )
+  h5$close_all()
+})
+
+test_that("invert_step.embed applies center and scale", {
+  tmp <- local_tempfile(fileext = ".h5")
+  h5 <- H5File$new(tmp, mode = "w")
+  basis_mat <- diag(2)
+  neuroarchive:::h5_write_dataset(h5, "/b/mat", basis_mat)
+  neuroarchive:::h5_write_dataset(h5, "/b/center", c(1,2))
+  neuroarchive:::h5_write_dataset(h5, "/b/scale", c(2,2))
+  desc <- list(
+    type = "embed",
+    params = list(basis_path = "/b/mat", center_data_with = "/b/center",
+                  scale_data_with = "/b/scale"),
+    inputs = c("dense"), outputs = c("coef")
+  )
+  coef_mat <- matrix(c(1,1,1,1), nrow = 2)
+  handle <- DataHandle$new(initial_stash = list(coef = coef_mat), h5 = h5)
+  h <- invert_step.embed("embed", desc, handle)
+  expected <- coef_mat %*% basis_mat
+  expected <- sweep(expected, 2, c(2,2), "*")
+  expected <- sweep(expected, 2, c(1,2), "+")
+  expect_equal(h$stash$dense, expected)
+  h5$close_all()
+})


### PR DESCRIPTION
## Summary
- add numeric input validation to `forward_step.embed`
- validate dataset existence in `invert_step.embed`
- expand embed tests for numeric input checks, missing datasets, and center/scale handling

## Testing
- `Rscript -e "devtools::test()"` *(fails: command not found)*