### PR TITLE
Sanitize run_id before dataset paths

### DIFF
--- a/R/transform_delta.R
+++ b/R/transform_delta.R
@@ -39,6 +39,7 @@ forward_step.delta <- function(type, desc, handle) {
   }
 
   run_id <- handle$current_run_id %||% "run-01"
+  run_id <- sanitize_run_id(run_id)
   plan <- handle$plan
   fname <- plan$get_next_filename(type)
   base <- tools::file_path_sans_ext(fname)

--- a/R/transform_embed.R
+++ b/R/transform_embed.R
@@ -50,6 +50,7 @@ forward_step.embed <- function(type, desc, handle) {
   }
 
   run_id <- handle$current_run_id %||% "run-01"
+  run_id <- sanitize_run_id(run_id)
   fname <- plan$get_next_filename(type)
   base_name <- tools::file_path_sans_ext(fname)
   coef_path <- paste0("/scans/", run_id, "/", base_name, "/coefficients")

--- a/R/transform_quant.R
+++ b/R/transform_quant.R
@@ -33,6 +33,7 @@ forward_step.quant <- function(type, desc, handle) {
   storage.mode(q) <- "integer"
 
   run_id <- handle$current_run_id %||% "run-01"
+  run_id <- sanitize_run_id(run_id)
   data_path <- paste0("/scans/", run_id, "/quantized")
   scale_path <- paste0("/scans/", run_id, "/quant_scale")
   offset_path <- paste0("/scans/", run_id, "/quant_offset")
@@ -65,6 +66,7 @@ forward_step.quant <- function(type, desc, handle) {
 #' @keywords internal
 invert_step.quant <- function(type, desc, handle) {
   run_id <- handle$current_run_id %||% "run-01"
+  run_id <- sanitize_run_id(run_id)
   data_path <- paste0("/scans/", run_id, "/quantized")
   scale_path <- paste0("/scans/", run_id, "/quant_scale")
   offset_path <- paste0("/scans/", run_id, "/quant_offset")

--- a/R/transform_sparsepca.R
+++ b/R/transform_sparsepca.R
@@ -41,8 +41,9 @@ forward_step.myorg.sparsepca <- function(type, desc, handle) {
   fname <- plan$get_next_filename(type)
   base <- tools::file_path_sans_ext(fname)
   basis_path <- paste0("/basis/", base, "/basis")
-  embed_path <- paste0("/scans/", handle$current_run_id %||% "run-01",
-                        "/", base, "/embedding")
+  run_id <- handle$current_run_id %||% "run-01"
+  run_id <- sanitize_run_id(run_id)
+  embed_path <- paste0("/scans/", run_id, "/", base, "/embedding")
   params_json <- jsonlite::toJSON(p, auto_unbox = TRUE)
 
   desc$version <- "1.0"

--- a/R/transform_temporal.R
+++ b/R/transform_temporal.R
@@ -32,6 +32,7 @@ forward_step.temporal <- function(type, desc, handle) {
   coeff <- crossprod(basis, X)
 
   run_id <- handle$current_run_id %||% "run-01"
+  run_id <- sanitize_run_id(run_id)
   plan <- handle$plan
   fname <- plan$get_next_filename(type)
   base_name <- tools::file_path_sans_ext(fname)

--- a/R/utils_hdf5.R
+++ b/R/utils_hdf5.R
@@ -456,3 +456,31 @@ resolve_run_ids <- function(patterns, available) {
   }
   unique(out)
 }
+
+#' Validate and sanitize run identifiers
+#'
+#' Ensures that \code{run_id} matches the expected ``"run-XX"`` pattern and
+#' does not contain path separators.  Returns the sanitized identifier or
+#' throws an error on invalid input.
+#'
+#' @param run_id Character scalar run identifier.
+#' @return The validated \code{run_id} string.
+#' @keywords internal
+sanitize_run_id <- function(run_id) {
+  stopifnot(is.character(run_id), length(run_id) == 1)
+  if (grepl("/|\\\\", run_id)) {
+    abort_lna(
+      "run_id must not contain path separators",
+      .subclass = "lna_error_validation",
+      location = "sanitize_run_id"
+    )
+  }
+  if (!grepl("^run-[0-9]{2}$", run_id)) {
+    abort_lna(
+      "run_id must match 'run-XX' pattern",
+      .subclass = "lna_error_validation",
+      location = "sanitize_run_id"
+    )
+  }
+  run_id
+}

--- a/tests/testthat/test-sanitize_run_id.R
+++ b/tests/testthat/test-sanitize_run_id.R
@@ -1,0 +1,14 @@
+library(testthat)
+library(neuroarchive)
+
+
+test_that("sanitize_run_id accepts valid id", {
+  expect_equal(neuroarchive:::sanitize_run_id("run-01"), "run-01")
+})
+
+test_that("sanitize_run_id rejects invalid patterns", {
+  expect_error(neuroarchive:::sanitize_run_id("run1"), class = "lna_error_validation")
+  expect_error(neuroarchive:::sanitize_run_id("run-1"), class = "lna_error_validation")
+  expect_error(neuroarchive:::sanitize_run_id("run/01"), class = "lna_error_validation")
+  expect_error(neuroarchive:::sanitize_run_id("run\\01"), class = "lna_error_validation")
+})


### PR DESCRIPTION
## Summary
- add `sanitize_run_id` helper in utils_hdf5
- use `sanitize_run_id` before dataset path construction in transforms
- test run id sanitisation

## Testing
- `R CMD check` *(fails: `R` not found)*