### PR TITLE
Validate input for quantization

### DIFF
--- a/R/transform_quant.R
+++ b/R/transform_quant.R
@@ -104,6 +104,13 @@ invert_step.quant <- function(type, desc, handle) {
 #' @keywords internal
 .quantize_global <- function(x, bits, method, center) {
   stopifnot(is.numeric(x))
+  if (any(!is.finite(x))) {
+    abort_lna(
+      "non-finite values found in input",
+      .subclass = "lna_error_validation",
+      location = ".quantize_global"
+    )
+  }
   rng <- range(x)
   m <- mean(x)
   s <- stats::sd(x)
@@ -138,6 +145,13 @@ invert_step.quant <- function(type, desc, handle) {
 #' Compute quantization parameters per voxel (time series)
 #' @keywords internal
 .quantize_voxel <- function(x, bits, method, center) {
+  if (any(!is.finite(x))) {
+    abort_lna(
+      "non-finite values found in input",
+      .subclass = "lna_error_validation",
+      location = ".quantize_voxel"
+    )
+  }
   dims <- dim(x)
   vox <- prod(dims[1:3])
   time <- dims[4]

--- a/tests/testthat/test-transform_quant.R
+++ b/tests/testthat/test-transform_quant.R
@@ -51,3 +51,21 @@ test_that("invert_step.quant applies roi_mask and time_idx", {
   out <- h$stash$input
   expect_equal(dim(out), c(sum(roi), 2))
 })
+
+test_that("quant transform errors on non-finite input", {
+  arr <- c(1, NA, 3)
+  tmp <- local_tempfile(fileext = ".h5")
+  expect_error(
+    write_lna(arr, file = tmp, transforms = "quant"),
+    class = "lna_error_validation",
+    regexp = "non-finite"
+  )
+
+  arr_nan <- c(1, NaN, 3)
+  tmp2 <- local_tempfile(fileext = ".h5")
+  expect_error(
+    write_lna(arr_nan, file = tmp2, transforms = "quant"),
+    class = "lna_error_validation",
+    regexp = "non-finite"
+  )
+})


### PR DESCRIPTION
## Summary
- stop on non-finite input in `.quantize_global` and `.quantize_voxel`
- test for error with NA and NaN values

## Testing
- `Rscript -e "testthat::test_dir('tests/testthat', reporter='summary')"` *(fails: `Rscript` not found)*