### PR TITLE
Validate quantization scale scope

### DIFF
--- a/R/transform_quant.R
+++ b/R/transform_quant.R
@@ -9,6 +9,11 @@ forward_step.quant <- function(type, desc, handle) {
   center <- p$center %||% TRUE
   scope <- p$scale_scope %||% "global"
 
+  if (!scope %in% c("global", "voxel")) {
+    warning(sprintf("unknown scale_scope '%s'; falling back to 'global'", scope))
+    scope <- "global"
+  }
+
   input_key <- if (!is.null(desc$inputs)) desc$inputs[[1]] else "input"
   x <- handle$get_inputs(input_key)[[1]]
 


### PR DESCRIPTION
## Summary
- warn if `scale_scope` is not `"global"` or `"voxel"` in `forward_step.quant`

## Testing
- `Rscript -e 'devtools::test()'` *(fails: Rscript not found)*