### PR TITLE
Implement cache clearing helpers

### DIFF
--- a/R/utils_defaults.R
+++ b/R/utils_defaults.R
@@ -11,6 +11,28 @@
 .default_param_cache <- new.env(parent = emptyenv())
 .required_param_cache <- new.env(parent = emptyenv())
 
+#' Clear the default parameter cache
+#'
+#' Removes all cached default parameter lists.
+#'
+#' @return invisible(NULL)
+#' @keywords internal
+default_param_cache_clear <- function() {
+  rm(list = ls(envir = .default_param_cache, all.names = TRUE), envir = .default_param_cache)
+  invisible(NULL)
+}
+
+#' Clear the required parameter cache
+#'
+#' Removes all cached required parameter vectors.
+#'
+#' @return invisible(NULL)
+#' @keywords internal
+required_param_cache_clear <- function() {
+  rm(list = ls(envir = .required_param_cache, all.names = TRUE), envir = .required_param_cache)
+  invisible(NULL)
+}
+
 
 # Recursively extract `default` values from a parsed JSON schema list
 .extract_schema_defaults <- function(node) {

--- a/tests/testthat/test-options_defaults.R
+++ b/tests/testthat/test-options_defaults.R
@@ -7,8 +7,7 @@ opts_env <- get(".lna_opts", envir = neuroarchive:::lna_options_env)
 # Ensure a clean state
 teardown({
   rm(list = ls(envir = opts_env), envir = opts_env)
-  cache_env <- get(".default_param_cache", envir = asNamespace("neuroarchive"))
-  rm(list = ls(envir = cache_env), envir = cache_env)
+  neuroarchive:::default_param_cache_clear()
   schema_env <- get(".schema_cache", envir = asNamespace("neuroarchive"))
   rm(list = ls(envir = schema_env), envir = schema_env)
 })
@@ -31,9 +30,9 @@ test_that("lna_options set and get work", {
 # Test default_params caching behavior
 
 test_that("default_params warns and caches empty list when schema missing", {
+  neuroarchive:::default_param_cache_clear()
   cache_env <- get(".default_param_cache", envir = asNamespace("neuroarchive"))
   schema_env <- get(".schema_cache", envir = asNamespace("neuroarchive"))
-  rm(list = ls(envir = cache_env), envir = cache_env)
   rm(list = ls(envir = schema_env), envir = schema_env)
 
   expect_warning(p1 <- neuroarchive:::default_params("foo"), "not found")
@@ -46,9 +45,9 @@ test_that("default_params warns and caches empty list when schema missing", {
 })
 
 test_that("default_params loads defaults from schema and caches", {
+  neuroarchive:::default_param_cache_clear()
   cache_env <- get(".default_param_cache", envir = asNamespace("neuroarchive"))
   schema_env <- get(".schema_cache", envir = asNamespace("neuroarchive"))
-  rm(list = ls(envir = cache_env), envir = cache_env)
   rm(list = ls(envir = schema_env), envir = schema_env)
 
   expect_false("test" %in% ls(envir = cache_env))

--- a/tests/testthat/test-plugin_discovery.R
+++ b/tests/testthat/test-plugin_discovery.R
@@ -3,8 +3,7 @@ library(withr)
 
 # Ensure caches cleared between tests
 teardown({
-  cache_env <- get(".default_param_cache", envir = asNamespace("neuroarchive"))
-  rm(list = ls(envir = cache_env), envir = cache_env)
+  neuroarchive:::default_param_cache_clear()
   schema_env <- get(".schema_cache", envir = asNamespace("neuroarchive"))
   rm(list = ls(envir = schema_env), envir = schema_env)
 })

--- a/tests/testthat/test-transform_basis.R
+++ b/tests/testthat/test-transform_basis.R
@@ -3,8 +3,7 @@ library(neuroarchive)
 
 
 test_that("default_params for basis loads schema", {
-  cache_env <- get(".default_param_cache", envir = asNamespace("neuroarchive"))
-  rm(list = ls(envir = cache_env), envir = cache_env)
+  neuroarchive:::default_param_cache_clear()
   p <- neuroarchive:::default_params("basis")
   expect_equal(p$method, "pca")
   expect_true(is.numeric(p$k))

--- a/tests/testthat/test-transform_delta.R
+++ b/tests/testthat/test-transform_delta.R
@@ -6,8 +6,7 @@ library(withr)
 
 
 test_that("default_params for delta loads schema", {
-  cache_env <- get(".default_param_cache", envir = asNamespace("neuroarchive"))
-  rm(list = ls(envir = cache_env), envir = cache_env)
+  neuroarchive:::default_param_cache_clear()
   p <- neuroarchive:::default_params("delta")
   expect_equal(p$order, 1)
 

--- a/tests/testthat/test-transform_embed.R
+++ b/tests/testthat/test-transform_embed.R
@@ -3,8 +3,7 @@ library(neuroarchive)
 
 
 test_that("default_params for embed loads schema", {
-  cache_env <- get(".default_param_cache", envir = asNamespace("neuroarchive"))
-  rm(list = ls(envir = cache_env), envir = cache_env)
+  neuroarchive:::default_param_cache_clear()
   p <- neuroarchive:::default_params("embed")
   expect_equal(p$basis_path, "")
   expect_null(p$center_data_with)

--- a/tests/testthat/test-transform_quant.R
+++ b/tests/testthat/test-transform_quant.R
@@ -5,8 +5,7 @@ library(withr)
 
 
 test_that("default_params for quant loads schema", {
-  cache_env <- get(".default_param_cache", envir = asNamespace("neuroarchive"))
-  rm(list = ls(envir = cache_env), envir = cache_env)
+  neuroarchive:::default_param_cache_clear()
   p <- neuroarchive:::default_params("quant")
   expect_equal(p$bits, 8)
   expect_equal(p$method, "range")

--- a/tests/testthat/test-transform_sparsepca.R
+++ b/tests/testthat/test-transform_sparsepca.R
@@ -4,8 +4,7 @@ library(withr)
 
 
 test_that("default_params for myorg.sparsepca loads schema", {
-  cache_env <- get(".default_param_cache", envir = asNamespace("neuroarchive"))
-  rm(list = ls(envir = cache_env), envir = cache_env)
+  neuroarchive:::default_param_cache_clear()
   p <- neuroarchive:::default_params("myorg.sparsepca")
   expect_equal(p$k, 50)
   expect_equal(p$alpha, 0.001)

--- a/tests/testthat/test-transform_temporal.R
+++ b/tests/testthat/test-transform_temporal.R
@@ -33,8 +33,7 @@ test_that("invert_step.temporal applies time_idx subset", {
 
 
 test_that("default_params for temporal loads schema", {
-  cache_env <- get(".default_param_cache", envir = asNamespace("neuroarchive"))
-  rm(list = ls(envir = cache_env), envir = cache_env)
+  neuroarchive:::default_param_cache_clear()
   p <- neuroarchive:::default_params("temporal")
   expect_equal(p$kind, "dct")
   expect_equal(p$scope, "global")


### PR DESCRIPTION
## Summary
- add `default_param_cache_clear()` and `required_param_cache_clear()` helpers
- use the cache clearing helpers in tests

## Testing
- `R -q -e "devtools::test()"` *(fails: `R: command not found`)*