### PR TITLE
Handle defaults in array schemas

### DIFF
--- a/R/utils_defaults.R
+++ b/R/utils_defaults.R
@@ -32,6 +32,20 @@
     }
   }
 
+  if (is.list(node$items)) {
+    if (is.null(names(node$items))) {
+      item_vals <- lapply(node$items, .extract_schema_defaults)
+      if (any(vapply(item_vals, Negate(is.null), logical(1)))) {
+        defaults$items <- item_vals
+      }
+    } else {
+      val <- .extract_schema_defaults(node$items)
+      if (!is.null(val)) {
+        defaults$items <- val
+      }
+    }
+  }
+
   if (length(defaults) > 0) defaults else NULL
 }
 

--- a/inst/schemas/test_array.schema.json
+++ b/inst/schemas/test_array.schema.json
@@ -1,0 +1,19 @@
+{
+  "title": "Test Array Defaults Schema",
+  "type": "object",
+  "properties": {
+    "numArray": {
+      "type": "array",
+      "items": {"type": "integer", "default": 2}
+    },
+    "objArray": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "flag": {"type": "boolean", "default": true}
+        }
+      }
+    }
+  }
+}

--- a/tests/testthat/test-options_defaults.R
+++ b/tests/testthat/test-options_defaults.R
@@ -60,3 +60,14 @@ test_that("default_params loads defaults from schema and caches", {
   d2 <- neuroarchive:::default_params("test")
   expect_identical(d1, d2)
 })
+
+test_that("defaults are extracted from array items", {
+  cache_env <- get(".default_param_cache", envir = asNamespace("neuroarchive"))
+  schema_env <- get(".schema_cache", envir = asNamespace("neuroarchive"))
+  rm(list = ls(envir = cache_env), envir = cache_env)
+  rm(list = ls(envir = schema_env), envir = schema_env)
+
+  d <- neuroarchive:::default_params("test_array")
+  expect_equal(d$numArray$items, 2)
+  expect_equal(d$objArray$items, list(flag = TRUE))
+})


### PR DESCRIPTION
## Summary
- extend `.extract_schema_defaults()` so that it also looks under `items`
- add a schema with array fields to exercise the new behaviour
- test that defaults within array `items` are extracted correctly

## Testing
- `R -q -e 'print("test")'` *(fails: `bash: R: command not found`)*
- `Rscript -e 'print("test")'` *(fails: `bash: Rscript: command not found`)*