### PR TITLE
Add roxygen docs for default wrappers

### DIFF
--- a/R/utils_defaults.R
+++ b/R/utils_defaults.R
@@ -167,44 +167,43 @@ resolve_transform_params <- function(transforms, transform_params = list()) {
   merged
 }
 
-#' Default parameters for the 'quant' transform
-#'
-#' Convenience wrapper around `default_params("quant")`.
+#' @title Default parameters for the 'quant' transform
+#' @description Convenience wrapper around `default_params("quant")`.
+#' @seealso default_params
 #' @export
 lna_default.quant <- function() {
   default_params("quant")
 }
 
-#' Default parameters for the 'basis' transform
-#'
-#' Convenience wrapper around `default_params("basis")`.
+#' @title Default parameters for the 'basis' transform
+#' @description Convenience wrapper around `default_params("basis")`.
+#' @seealso default_params
 #' @export
 lna_default.basis <- function() {
   default_params("basis")
 }
 
-#' Default parameters for the 'embed' transform
-#'
-#' Convenience wrapper around `default_params("embed")`.
+#' @title Default parameters for the 'embed' transform
+#' @description Convenience wrapper around `default_params("embed")`.
+#' @seealso default_params
 #' @export
 lna_default.embed <- function() {
   default_params("embed")
 }
 
 
-#' Default parameters for the 'delta' transform
-#'
-#' Convenience wrapper around `default_params("delta")`.
+#' @title Default parameters for the 'delta' transform
+#' @description Convenience wrapper around `default_params("delta")`.
+#' @seealso default_params
 #' @export
 lna_default.delta <- function() {
   default_params("delta")
 }
 
-#' Default parameters for the 'temporal' transform
-#'
-#' Convenience wrapper around `default_params("temporal")`.
+#' @title Default parameters for the 'temporal' transform
+#' @description Convenience wrapper around `default_params("temporal")`.
+#' @seealso default_params
 #' @export
 lna_default.temporal <- function() {
   default_params("temporal")
-
 }

--- a/man/lna_default.basis.Rd
+++ b/man/lna_default.basis.Rd
@@ -1,0 +1,10 @@
+\name{lna_default.basis}
+\alias{lna_default.basis}
+\title{Default parameters for the 'basis' transform}
+\usage{
+lna_default.basis()
+}
+\description{
+Convenience wrapper around \code{\link{default_params}}("basis").
+}
+\seealso{\code{\link{default_params}}}

--- a/man/lna_default.delta.Rd
+++ b/man/lna_default.delta.Rd
@@ -1,0 +1,10 @@
+\name{lna_default.delta}
+\alias{lna_default.delta}
+\title{Default parameters for the 'delta' transform}
+\usage{
+lna_default.delta()
+}
+\description{
+Convenience wrapper around \code{\link{default_params}}("delta").
+}
+\seealso{\code{\link{default_params}}}

--- a/man/lna_default.embed.Rd
+++ b/man/lna_default.embed.Rd
@@ -1,0 +1,10 @@
+\name{lna_default.embed}
+\alias{lna_default.embed}
+\title{Default parameters for the 'embed' transform}
+\usage{
+lna_default.embed()
+}
+\description{
+Convenience wrapper around \code{\link{default_params}}("embed").
+}
+\seealso{\code{\link{default_params}}}

--- a/man/lna_default.quant.Rd
+++ b/man/lna_default.quant.Rd
@@ -1,0 +1,10 @@
+\name{lna_default.quant}
+\alias{lna_default.quant}
+\title{Default parameters for the 'quant' transform}
+\usage{
+lna_default.quant()
+}
+\description{
+Convenience wrapper around \code{\link{default_params}}("quant").
+}
+\seealso{\code{\link{default_params}}}

--- a/man/lna_default.temporal.Rd
+++ b/man/lna_default.temporal.Rd
@@ -1,0 +1,10 @@
+\name{lna_default.temporal}
+\alias{lna_default.temporal}
+\title{Default parameters for the 'temporal' transform}
+\usage{
+lna_default.temporal()
+}
+\description{
+Convenience wrapper around \code{\link{default_params}}("temporal").
+}
+\seealso{\code{\link{default_params}}}


### PR DESCRIPTION
## Summary
- provide `@title`, `@description`, and `@seealso` tags for wrapper functions
- add Rd docs for default parameter helper wrappers

## Testing
- `Rscript -e 'roxygen2::roxygenize()'` *(fails: `Rscript` not found)*