### PR TITLE
Fix scaffolder default_params call

### DIFF
--- a/R/utils_scaffold.R
+++ b/R/utils_scaffold.R
@@ -24,20 +24,21 @@ scaffold_transform <- function(type) {
   dir.create(dirname(schema_path), recursive = TRUE, showWarnings = FALSE)
   dir.create(dirname(test_path), recursive = TRUE, showWarnings = FALSE)
 
+  pkg <- utils::packageName(environment(scaffold_transform))
   r_template <- sprintf(
 "forward_step.%1$s <- function(type, desc, handle) {
-  params <- default_params('%1$s')
+  params <- %2$s:::default_params('%1$s')
   ## TODO: implement forward transform
   handle
 }
 
 invert_step.%1$s <- function(type, desc, handle) {
-  params <- default_params('%1$s')
+  params <- %2$s:::default_params('%1$s')
   ## TODO: implement inverse transform
   handle
 }
 ",
-    type)
+    type, pkg)
 
   writeLines(r_template, r_path)
 

--- a/tests/testthat/test-scaffold_transform.R
+++ b/tests/testthat/test-scaffold_transform.R
@@ -13,8 +13,10 @@ test_that("scaffold_transform creates template files", {
   expect_true(file.exists(paths$test))
 
   r_lines <- readLines(paths$r_file)
+  pkg <- utils::packageName(environment(scaffold_transform))
+  ns_call <- sprintf("%s:::default_params('mycustom')", pkg)
   expect_true(any(grepl("forward_step.mycustom", r_lines, fixed = TRUE)))
-  expect_true(any(grepl("default_params('mycustom')", r_lines, fixed = TRUE)))
+  expect_true(any(grepl(ns_call, r_lines, fixed = TRUE)))
 })
 
 test_that("scaffold_transform warns on namespace collisions", {


### PR DESCRIPTION
## Summary
- use `pkg:::default_params()` inside scaffold template
- adjust scaffold unit test to expect namespaced default params call

## Testing
- ❌ `R -q -e "sessionInfo()"` (fails: `R: command not found`)
- ❌ `Rscript -e "sessionInfo()"` (fails: `Rscript: command not found`)
