### PR TITLE
Add safe validation for transform type

### DIFF
--- a/R/plan.R
+++ b/R/plan.R
@@ -118,6 +118,20 @@ Plan <- R6::R6Class("Plan",
     #' @return Character string (e.g., "00_type.json").
     get_next_filename = function(type) {
       stopifnot(is.character(type), length(type) == 1)
+
+      if (grepl("\.\.", type) || grepl("/", type) || grepl("\\\\", type)) {
+        stop(sprintf(
+          "Invalid characters found in type '%s'", type
+        ), call. = FALSE)
+      }
+
+      safe_pat <- "^[A-Za-z][A-Za-z0-9_.]*$"
+      if (!grepl(safe_pat, type)) {
+        stop(sprintf(
+          "Invalid transform type '%s'. Must match %s", type, safe_pat
+        ), call. = FALSE)
+      }
+
       index_str <- sprintf("%02d", self$next_index)
       filename <- paste0(index_str, "_", type, ".json")
       return(filename)

--- a/tests/testthat/test-plan.R
+++ b/tests/testthat/test-plan.R
@@ -149,6 +149,9 @@ test_that("Plan add_descriptor and get_next_filename work correctly", {
   expect_error(plan$add_descriptor(123, list()))
   expect_error(plan$add_descriptor("name", "not_a_list"))
   expect_error(plan$get_next_filename(123))
+  expect_error(plan$get_next_filename("../bad"))
+  expect_error(plan$get_next_filename("bad/type"))
+  expect_error(plan$get_next_filename("bad\\\\type"))
 })
 
 test_that("Plan mark_payload_written works correctly", {


### PR DESCRIPTION
## Summary
- validate transform type in `Plan$get_next_filename`
- add tests for invalid type strings

## Testing
- `Rscript -e 'testthat::test_dir("tests/testthat")'` *(fails: command not found)*