### PR TITLE
Document schema cache

### DIFF
--- a/R/utils_json.R
+++ b/R/utils_json.R
@@ -89,14 +89,16 @@ write_json_descriptor <- function(h5_group, name, desc_list) {
 } 
 #' Schema Cache Environment
 #'
-#' Creates an internal environment to store compiled JSON schemas.
-#' Only a clearing function is provided.
+#' Internal environment used to store compiled JSON schema objects for
+#' transform validation.  It is not intended for direct use but can be
+#' emptied via [schema_cache_clear()] when needed (e.g. during unit
+#' testing).
 #' @keywords internal
 .schema_cache <- new.env(parent = emptyenv())
 
 #' Clear the schema cache
 #'
-#' Removes all entries from the internal schema cache.
+#' Removes all entries from the internal \code{.schema_cache} environment.
 #' Intended primarily for unit tests or to avoid stale compiled objects.
 #'
 #' @return invisible(NULL)

--- a/man/schema_cache_clear.Rd
+++ b/man/schema_cache_clear.Rd
@@ -1,0 +1,15 @@
+\name{schema_cache_clear}
+\alias{schema_cache_clear}
+\alias{.schema_cache}
+\title{Schema cache environment}
+\usage{
+schema_cache_clear()
+}
+\description{
+\code{.schema_cache} is an internal environment that stores compiled JSON
+schemas used during validation.  It can be emptied with
+\code{schema_cache_clear()} when needed, typically for testing or to
+avoid stale cached objects.
+}
+\value{Invisibly returns \code{NULL}.}
+\keyword{internal}


### PR DESCRIPTION
## Summary
- document `.schema_cache` usage and clarify it can be emptied via `schema_cache_clear()`
- clarify `.schema_cache` in function docs
- add manual page for `schema_cache_clear` and `.schema_cache`

## Testing
- `R -q -e 'roxygen2::roxygenize()'` *(fails: command not found)*
- `R -q -e 'devtools::test()'` *(fails: command not found)*