### PR TITLE
Ensure dataset handles closed in validation

### DIFF
--- a/R/validate.R
+++ b/R/validate.R
@@ -121,6 +121,7 @@ validate_lna <- function(file, strict = TRUE, checksum = TRUE) {
             }
 
             dset <- h5[[path]]
+            on.exit(if (inherits(dset, "H5D")) dset$close(), add = TRUE)
             if (!is.null(ds$dims)) {
               if (!identical(as.integer(ds$dims), as.integer(dset$dims))) {
                 fail(sprintf("Dimensions mismatch for dataset '%s'", path))
@@ -129,6 +130,7 @@ validate_lna <- function(file, strict = TRUE, checksum = TRUE) {
 
             if (!is.null(ds$dtype)) {
               dt <- dset$get_type()
+              on.exit(if (inherits(dt, "H5T")) dt$close(), add = TRUE)
               class_id <- dt$get_class()
               size <- dt$get_size()
               actual <- switch(as.character(class_id),


### PR DESCRIPTION
## Summary
- protect dataset resources during validation by deferring `close()` calls

## Testing
- `R -q -e "devtools::test()"` *(fails: `bash: R: command not found`)*