### PR TITLE
Handle dataset read errors in validate_lna

### DIFF
--- a/R/validate.R
+++ b/R/validate.R
@@ -141,7 +141,13 @@ validate_lna <- function(file, strict = TRUE, checksum = TRUE) {
               }
             }
 
-            data <- tryCatch(h5_read(root, path), error = function(e) NULL)
+            data <- tryCatch(
+              h5_read(root, path),
+              error = function(e) {
+                fail(sprintf("Error reading dataset '%s': %s", path, e$message))
+                NULL
+              }
+            )
             if (is.numeric(data)) {
               if (all(is.na(data)) || all(data == 0)) {
                 fail(sprintf("Dataset '%s' contains only zeros/NaN", path))

--- a/tests/testthat/test-validate_lna.R
+++ b/tests/testthat/test-validate_lna.R
@@ -126,3 +126,14 @@ test_that("validate_lna detects dimension mismatch hints", {
   neuroarchive:::close_h5_safely(h5)
   expect_error(validate_lna(tmp), class = "lna_error_validation")
 })
+
+test_that("validate_lna errors when dataset cannot be read", {
+  tmp <- local_tempfile(fileext = ".h5")
+  create_valid_lna(tmp)
+  h5 <- neuroarchive:::open_h5(tmp, mode = "r+")
+  h5$link_delete("scans/run-01/data")
+  h5$create_group("scans/run-01/data")
+  neuroarchive:::close_h5_safely(h5)
+
+  expect_error(validate_lna(tmp), class = "lna_error_validation")
+})


### PR DESCRIPTION
## Summary
- fail when reading datasets in `validate_lna` fails
- test that dataset read failures raise validation error

## Testing
- `R CMD check .` *(fails: R not installed)*