### PR TITLE
Update fail warnings in validation

### DIFF
--- a/R/validate.R
+++ b/R/validate.R
@@ -34,7 +34,7 @@ validate_lna <- function(file, strict = TRUE, checksum = TRUE) {
         location = sprintf("validate_lna:%s", file)
       )
     } else {
-      warning(msg)
+      warning(msg, call. = FALSE)
       issues <<- c(issues, msg)
       invisible(NULL)
     }


### PR DESCRIPTION
## Summary
- flag warnings in `fail()` with `call. = FALSE` to suppress call traces

## Testing
- `Rscript -e '1+1'` *(fails: command not found)*