### PR TITLE
Fix dataset closing behavior

### DIFF
--- a/R/materialise.R
+++ b/R/materialise.R
@@ -103,9 +103,8 @@ materialise_plan <- function(h5, plan, checksum = c("none", "sha256"),
     chunk_dims <- NULL
 
     attempt <- function(level, chunks) {
-      ds <- h5_write_dataset(root, path, data, chunk_dims = chunks,
-                             compression_level = level)
-      if (inherits(ds, "H5D")) ds$close()
+      h5_write_dataset(root, path, data, chunk_dims = chunks,
+                       compression_level = level)
       NULL
     }
 
@@ -161,8 +160,6 @@ materialise_plan <- function(h5, plan, checksum = c("none", "sha256"),
         location = sprintf("materialise_plan[%d]:%s", step_index, path),
         parent = res
       )
-    } else if (inherits(res, "H5D")) {
-      res$close()
     }
   }
 

--- a/R/utils_hdf5.R
+++ b/R/utils_hdf5.R
@@ -171,7 +171,7 @@ reduce_chunk_dims <- function(chunk, dtype_size, target_bytes) {
 #' @param data Numeric matrix/array to write.
 #' @param chunk_dims Optional integer vector specifying HDF5 chunk dimensions.
 #' @param compression_level Integer 0–9 giving gzip compression level.
-#' @return The created `H5D` dataset object (invisibly).
+#' @return Invisibly returns `TRUE` on success.
 h5_write_dataset <- function(h5_group, path, data,
                              chunk_dims = NULL, compression_level = 0) {
   stopifnot(inherits(h5_group, "H5Group"))
@@ -225,7 +225,8 @@ h5_write_dataset <- function(h5_group, path, data,
     dset <- create_fun(NULL)
   }
 
-  invisible(dset)
+  if (inherits(dset, "H5D")) dset$close()
+  invisible(TRUE)
 }
 
 

--- a/tests/testthat/test-h5_write_dataset.R
+++ b/tests/testthat/test-h5_write_dataset.R
@@ -10,11 +10,10 @@ test_that("h5_write_dataset writes dataset with compression", {
   root <- h5[["/"]]
 
   mat <- matrix(1:9, nrow = 3)
-  dset <- h5_write_dataset(root, "/group/data", mat, chunk_dims = c(2,2), compression_level = 6)
+  h5_write_dataset(root, "/group/data", mat, chunk_dims = c(2,2), compression_level = 6)
 
   expect_true(root$exists("group/data"))
-  expect_s3_class(dset, "H5D")
-
+  dset <- root[["/group/data"]]
   dcpl <- dset$get_create_plist()
   expect_equal(dcpl$get_chunk(2), c(2,2))
   expect_equal(dcpl$get_filter(0)$filter, hdf5r::h5const$H5Z_FILTER_DEFLATE)


### PR DESCRIPTION
## Summary
- close dataset handles in `h5_write_dataset` and return `TRUE`
- simplify payload write helper after dataset writer change
- update dataset writer test for new return type

## Testing
- `./run-tests.sh` *(fails: `R is not installed. Skipping R unit tests.`)*