### PR TITLE
Fix FX-T-4 test syntax

### DIFF
--- a/tests/testthat/test-transform_embed_inverse.R
+++ b/tests/testthat/test-transform_embed_inverse.R
@@ -64,8 +64,9 @@ test_that("invert_step.embed errors when datasets are missing", {
     invert_step.embed("embed", desc, handle),
     class = "lna_error_contract",
     regexp = "not found"
-    )
-  }
+  )
+  h5$close_all()
+})
 
 test_that("invert_step.embed errors when datasets missing", {
   tmp <- local_tempfile(fileext = ".h5")


### PR DESCRIPTION
## Summary
- close missing parenthesis in `invert_step.embed errors when datasets are missing`
- close HDF5 file in that test

## Testing
- `./run-tests.sh` *(fails: R is not installed)*