### PR TITLE
Prefix close_h5_safely calls

### DIFF
--- a/R/api.R
+++ b/R/api.R
@@ -87,7 +87,7 @@ write_lna <- function(x, file = NULL, transforms = character(),
     h5 <- open_h5(file, mode = "w")
   }
 
-  on.exit(close_h5_safely(h5))
+  on.exit(neuroarchive:::close_h5_safely(h5))
 
   materialise_plan(h5, result$plan,
                    header = result$handle$meta$header,
@@ -98,7 +98,7 @@ write_lna <- function(x, file = NULL, transforms = character(),
     h5_write_dataset(h5[["/"]], "spatial/block_table", as.matrix(block_table))
   }
 
-  close_h5_safely(h5)
+  neuroarchive:::close_h5_safely(h5)
 
   out_file <- if (in_memory) NULL else file
   out <- list(file = out_file, plan = result$plan,

--- a/R/core_read.R
+++ b/R/core_read.R
@@ -40,7 +40,7 @@ core_read <- function(file, run_id = NULL,
   output_dtype <- match.arg(output_dtype)
   h5 <- open_h5(file, mode = "r")
   if (!lazy) {
-    on.exit(close_h5_safely(h5))
+    on.exit(neuroarchive:::close_h5_safely(h5))
   }
 
   available_runs <- discover_run_ids(h5)

--- a/R/materialise.R
+++ b/R/materialise.R
@@ -213,13 +213,13 @@ materialise_plan <- function(h5, plan, checksum = c("none", "sha256"),
 
   if (checksum == "sha256") {
     file_path <- h5$filename
-    close_h5_safely(h5)
+      neuroarchive:::close_h5_safely(h5)
     if (is.character(file_path) && nzchar(file_path) && file.exists(file_path)) {
       hash_val <- digest::digest(file = file_path, algo = "sha256")
       h5_tmp <- open_h5(file_path, mode = "r+")
       root_tmp <- h5_tmp[["/"]]
       h5_attr_write(root_tmp, "lna_checksum", hash_val)
-      close_h5_safely(h5_tmp)
+        neuroarchive:::close_h5_safely(h5_tmp)
     } else {
       warning("Checksum requested but file path unavailable; skipping")
     }

--- a/R/reader.R
+++ b/R/reader.R
@@ -60,7 +60,7 @@ lna_reader <- R6::R6Class("lna_reader",
       self$subset_params <- subset_params
 
       h5 <- open_h5(file, mode = "r")
-      on.exit(close_h5_safely(h5))
+        on.exit(neuroarchive:::close_h5_safely(h5))
 
       runs_avail <- discover_run_ids(h5)
       runs <- resolve_run_ids(core_read_args$run_id, runs_avail)
@@ -82,7 +82,7 @@ lna_reader <- R6::R6Class("lna_reader",
     #' Close the HDF5 handle. Safe to call multiple times.
     close = function() {
       if (!is.null(self$h5)) {
-        close_h5_safely(self$h5)
+          neuroarchive:::close_h5_safely(self$h5)
         self$h5 <- NULL
       }
       self$data_cache <- NULL

--- a/R/validate.R
+++ b/R/validate.R
@@ -21,7 +21,7 @@ validate_lna <- function(file, strict = TRUE, checksum = TRUE) {
   stopifnot(is.character(file), length(file) == 1)
 
   h5 <- open_h5(file, mode = "r")
-  on.exit(close_h5_safely(h5))
+  on.exit(neuroarchive:::close_h5_safely(h5))
   root <- h5[["/"]]
 
   issues <- character()


### PR DESCRIPTION
## Summary
- call `neuroarchive:::close_h5_safely()` explicitly in API and util calls

## Testing
- `./run-tests.sh` *(fails: R is not installed)*