### PR TITLE
Fix test mocks for read_lna forwarding

### DIFF
--- a/tests/testthat/test-aliases.R
+++ b/tests/testthat/test-aliases.R
@@ -15,15 +15,6 @@ test_that("compress_fmri forwards to write_lna", {
   expect_identical(out, "res")
 })
 
-test_that("open_lna forwards to read_lna", {
-  captured <- NULL
-  with_mocked_bindings(
-    read_lna = function(...) { captured <<- list(...); "out" },
-    {
-      res <- open_lna(file = "bar.h5", lazy = TRUE)
-    }
-  )
-  expect_identical(captured$file, "bar.h5")
-  expect_true(captured$lazy)
-  expect_identical(res, "out")
+test_that("open_lna is an alias of read_lna", {
+  expect_identical(open_lna, read_lna)
 })

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -85,7 +85,7 @@ test_that("read_lna forwards arguments to core_read", {
       DataHandle$new()
     }, {
       read_lna("somefile.h5", run_id = "run-*", allow_plugins = "prompt", validate = TRUE,
-               output_dtype = "float64", lazy = TRUE)
+               output_dtype = "float64", lazy = FALSE)
     }
   )
 
@@ -94,7 +94,7 @@ test_that("read_lna forwards arguments to core_read", {
   expect_equal(captured$core$allow_plugins, "prompt")
   expect_true(captured$core$validate)
   expect_equal(captured$core$output_dtype, "float64")
-  expect_true(captured$core$lazy)
+  expect_false(captured$core$lazy)
 })
 
 test_that("read_lna lazy=TRUE keeps file open", {


### PR DESCRIPTION
## Summary
- update `open_lna` test to check alias identity
- avoid opening nonexistent file in `read_lna` forwarding test

## Testing
- `./run-tests.sh` *(fails: R is not installed)*