### PR TITLE
Fix tests for 3D input arrays

### DIFF
--- a/tests/testthat/test-aliases.R
+++ b/tests/testthat/test-aliases.R
@@ -7,7 +7,7 @@ test_that("compress_fmri forwards to write_lna", {
   with_mocked_bindings(
     write_lna = function(...) { captured <<- list(...); "res" },
     {
-      out <- compress_fmri(x = 1, file = "foo.h5")
+      out <- compress_fmri(x = array(1, dim = c(1, 1, 1)), file = "foo.h5")
     }
   )
   expect_identical(captured$x, 1)

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -5,7 +5,7 @@ library(withr)
 # Basic functionality test using actual file
 
 test_that("write_lna with file=NULL uses in-memory HDF5", {
-  result <- write_lna(x = 1, file = NULL, transforms = character(0))
+  result <- write_lna(x = array(1, dim = c(1, 1, 1)), file = NULL, transforms = character(0))
   expect_s3_class(result, "lna_write_result")
   expect_null(result$file)
   expect_true(inherits(result$plan, "Plan"))
@@ -13,7 +13,7 @@ test_that("write_lna with file=NULL uses in-memory HDF5", {
 
 test_that("write_lna writes header attributes to file", {
   tmp <- local_tempfile(fileext = ".h5")
-  result <- write_lna(x = 1, file = tmp, transforms = character(0),
+  result <- write_lna(x = array(1, dim = c(1, 1, 1)), file = tmp, transforms = character(0),
                       header = list(foo = 2L))
   expect_true(file.exists(tmp))
   h5 <- neuroarchive:::open_h5(tmp, mode = "r")
@@ -24,7 +24,7 @@ test_that("write_lna writes header attributes to file", {
 
 test_that("write_lna plugins list is written to /plugins", {
   tmp <- local_tempfile(fileext = ".h5")
-  write_lna(x = 1, file = tmp, transforms = character(0),
+  write_lna(x = array(1, dim = c(1, 1, 1)), file = tmp, transforms = character(0),
             plugins = list(myplugin = list(a = 1)))
   h5 <- neuroarchive:::open_h5(tmp, mode = "r")
   expect_true(h5$exists("plugins/myplugin.json"))
@@ -98,7 +98,7 @@ test_that("read_lna forwards arguments to core_read", {
 })
 
 test_that("read_lna lazy=TRUE keeps file open", {
-  result <- write_lna(x = 1, file = NULL, transforms = character(0))
+  result <- write_lna(x = array(1, dim = c(1, 1, 1)), file = NULL, transforms = character(0))
   handle <- read_lna(result$file, lazy = TRUE)
   expect_true(handle$h5$is_valid())
   neuroarchive:::close_h5_safely(handle$h5)

--- a/tests/testthat/test-core_write.R
+++ b/tests/testthat/test-core_write.R
@@ -22,7 +22,7 @@ withr::defer({
 # Core test
 
 test_that("core_write executes forward loop and merges params", {
-  result <- core_write(x = 1, transforms = c("tA", "tB"), transform_params = list(tB = list(foo = "bar")))
+  result <- core_write(x = array(1, dim = c(1, 1, 1)), transforms = c("tA", "tB"), transform_params = list(tB = list(foo = "bar")))
   plan <- result$plan
   expect_equal(plan$next_index, 2L)
   expect_equal(length(plan$descriptors), 2)
@@ -40,7 +40,7 @@ test_that("transform_params merging honors precedence and deep merge", {
       list(a = 1, b = 2, nested = list(x = 0, y = 0))
     }, {
       res <- core_write(
-        x = 1,
+        x = array(1, dim = c(1, 1, 1)),
         transforms = c("tB"),
         transform_params = list(tB = list(b = 20, nested = list(y = 5)))
       )
@@ -55,7 +55,7 @@ test_that("transform_params merging honors precedence and deep merge", {
 
 test_that("unknown transform names in transform_params error", {
   expect_error(
-    core_write(x = 1, transforms = c("tA"), transform_params = list(tB = list())),
+    core_write(x = array(1, dim = c(1, 1, 1)), transforms = c("tA"), transform_params = list(tB = list())),
     class = "lna_error_validation"
   )
 })
@@ -71,7 +71,7 @@ test_that("unnamed list input generates run names accessible to forward_step", {
   assign("forward_step.runTest", forward_step.runTest, envir = .GlobalEnv)
   withr::defer(rm(forward_step.runTest, envir = .GlobalEnv))
 
-  res <- core_write(x = list(matrix(1), matrix(2)), transforms = "runTest")
+  res <- core_write(x = list(array(1, dim = c(1,1,1)), array(2, dim = c(1,1,1))), transforms = "runTest")
 
   expect_equal(captured$run_ids, c("run-01", "run-02"))
   expect_equal(captured$names, c("run-01", "run-02"))
@@ -100,7 +100,7 @@ test_that("core_write works with progress handlers", {
   progressr::handlers(progressr::handler_void)
   expect_silent(
     progressr::with_progress(
-      core_write(x = 1, transforms = c("tA"))
+      core_write(x = array(1, dim = c(1, 1, 1)), transforms = c("tA"))
     )
   )
   progressr::handlers(NULL)

--- a/tests/testthat/test-error_provenance.R
+++ b/tests/testthat/test-error_provenance.R
@@ -9,7 +9,7 @@ assign("forward_step.fail", forward_step.fail, envir = .GlobalEnv)
 withr::defer(rm("forward_step.fail", envir = .GlobalEnv))
 
 test_that("core_write reports step provenance", {
-  err <- expect_error(core_write(x = 1, transforms = "fail"))
+  err <- expect_error(core_write(x = array(1, dim = c(1, 1, 1)), transforms = "fail"))
   expect_true(grepl("forward_step.fail\[0\]", err$location))
 })
 

--- a/tests/testthat/test-write_lna_parallel.R
+++ b/tests/testthat/test-write_lna_parallel.R
@@ -8,7 +8,7 @@ test_that("write_lna temp file can be atomically renamed", {
   final <- file.path(dir, "dest.lna.h5")
   tmp <- tempfile(tmpdir = dir, fileext = ".h5")
 
-  res <- write_lna(x = 1, file = tmp, transforms = character(0))
+  res <- write_lna(x = array(1, dim = c(1, 1, 1)), file = tmp, transforms = character(0))
   expect_true(file.exists(tmp))
   expect_true(file.rename(tmp, final))
   expect_false(file.exists(tmp))


### PR DESCRIPTION
## Summary
- update write_lna and core_write tests to supply 3D arrays instead of scalars
- adjust list input tests to use minimal 3D arrays

## Testing
- `./run-tests.sh` *(fails: R is not installed)*