### PR TITLE
Fix plugin handling when writing

### DIFF
--- a/R/api.R
+++ b/R/api.R
@@ -89,9 +89,12 @@ write_lna <- function(x, file = NULL, transforms = character(),
 
   on.exit(neuroarchive:::close_h5_safely(h5))
 
+  plugins <- result$handle$meta$plugins
+  if (length(plugins) == 0) plugins <- NULL
+
   materialise_plan(h5, result$plan,
                    header = result$handle$meta$header,
-                   plugins = result$handle$meta$plugins)
+                   plugins = plugins)
 
 
   if (!is.null(block_table)) {

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -34,6 +34,15 @@ test_that("write_lna plugins list is written to /plugins", {
   neuroarchive:::close_h5_safely(h5)
 })
 
+test_that("write_lna omits plugins group when list is empty", {
+  tmp <- local_tempfile(fileext = ".h5")
+  write_lna(x = array(1, dim = c(1, 1, 1)), file = tmp,
+            transforms = character(0), plugins = list())
+  h5 <- neuroarchive:::open_h5(tmp, mode = "r")
+  expect_false(h5$exists("plugins"))
+  neuroarchive:::close_h5_safely(h5)
+})
+
 # Parameter forwarding for write_lna
 
 test_that("write_lna forwards arguments to core_write and materialise_plan", {


### PR DESCRIPTION
## Summary
- avoid writing empty `/plugins` group when writing an LNA file
- test that empty plugin lists omit the `/plugins` group

## Testing
- `./run-tests.sh` *(fails: R is not installed)*