### PR TITLE
Fix compress_fmri alias test and docs

### DIFF
--- a/R/api.R
+++ b/R/api.R
@@ -187,7 +187,8 @@ read_lna <- function(file, run_id = NULL,
 
 #' Convenience alias for `write_lna`
 #'
-#' `compress_fmri()` simply forwards its arguments to `write_lna()`.
+#' `compress_fmri()` simply forwards its arguments to `write_lna()` without
+#' altering the dimensions of the input.
 #'
 #' @inheritParams write_lna
 #' @seealso write_lna

--- a/man/compress_fmri.Rd
+++ b/man/compress_fmri.Rd
@@ -4,5 +4,7 @@
 \usage{
 compress_fmri(...)
 }
-\description{Calls \code{\link{write_lna}} with the supplied arguments.}
+\description{Calls \code{\link{write_lna}} with the supplied arguments.
+This function simply forwards to \code{write_lna} without modifying the
+dimensions of the provided data.}
 \seealso{\code{\link{write_lna}}}

--- a/tests/testthat/test-aliases.R
+++ b/tests/testthat/test-aliases.R
@@ -7,7 +7,7 @@ test_that("compress_fmri forwards to write_lna", {
   with_mocked_bindings(
     write_lna = function(...) { captured <<- list(...); "res" },
     {
-      out <- compress_fmri(x = array(1, dim = c(1, 1, 1)), file = "foo.h5")
+      out <- compress_fmri(x = 1, file = "foo.h5")
     }
   )
   expect_identical(captured$x, 1)


### PR DESCRIPTION
## Summary
- fix alias unit test for `compress_fmri`
- clarify docs that `compress_fmri` forwards to `write_lna` without altering dimensions

## Testing
- `./run-tests.sh` *(fails: R not installed)*