### PR TITLE
Accept empty lists in validate_named_list

### DIFF
--- a/R/core_write.R
+++ b/R/core_write.R
@@ -133,7 +133,7 @@ validate_mask <- function(mask) {
 #'
 #' @param lst List or `NULL`.
 #' @param field Field name used in error messages.
-#' @return The validated list or an empty list if `NULL`.
+#' @return The validated list or an empty list if `NULL` or empty.
 #' @keywords internal
 validate_named_list <- function(lst, field) {
   if (is.null(lst)) {
@@ -141,6 +141,11 @@ validate_named_list <- function(lst, field) {
   }
 
   stopifnot(is.list(lst))
+
+  if (length(lst) == 0) {
+    return(list())
+  }
+
   if (is.null(names(lst)) || any(names(lst) == "")) {
     abort_lna(
       sprintf("%s must be a named list", field),

--- a/man/validate_named_list.Rd
+++ b/man/validate_named_list.Rd
@@ -12,7 +12,7 @@ validate_named_list(lst, field)
 \item{field}{Field name used in error messages.}
 }
 \value{
-The validated list or an empty list if `NULL`.
+The validated list or an empty list if `NULL` or empty.
 }
 \description{
 Used for the `header` and `plugins` arguments in `core_write`.


### PR DESCRIPTION
## Summary
- handle empty lists in `validate_named_list`
- document that empty lists are allowed

## Testing
- `bash run-tests.sh` *(fails: R is not installed)*