### PR TITLE
Fix dataset creation arg

### DIFF
--- a/R/utils_hdf5.R
+++ b/R/utils_hdf5.R
@@ -207,7 +207,7 @@ h5_write_dataset <- function(h5_group, path, data,
 
   create_fun <- function(level) {
     grp$create_dataset(ds_name,
-                       data = data,
+                       robj = data,
                        chunk_dims = chunk_dims,
                        gzip_level = level)
   }


### PR DESCRIPTION
## Summary
- use robj= data when creating datasets in h5_write_dataset

## Testing
- `./run-tests.sh` *(fails: R is not installed)*