### PR TITLE
Fix with_mocked_bindings package args

### DIFF
--- a/tests/testthat/test-aliases.R
+++ b/tests/testthat/test-aliases.R
@@ -6,6 +6,7 @@ test_that("compress_fmri forwards to write_lna", {
   captured <- NULL
   with_mocked_bindings(
     write_lna = function(...) { captured <<- list(...); "res" },
+    .package = "neuroarchive",
     {
       out <- compress_fmri(x = 1, file = "foo.h5")
     }

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -62,7 +62,9 @@ test_that("write_lna forwards arguments to core_write and materialise_plan", {
                                 plugins = NULL) {
       captured$mat <- list(is_h5 = inherits(h5, "H5File"), plan = plan,
                            header = header, plugins = plugins)
-    }, {
+    },
+    .package = "neuroarchive",
+    {
       write_lna(x = 42, file = tempfile(fileext = ".h5"),
                 transforms = c("tA"),
                 transform_params = list(tA = list(foo = "bar")),
@@ -92,7 +94,9 @@ test_that("read_lna forwards arguments to core_read", {
                             validate = validate, output_dtype = output_dtype,
                             lazy = lazy)
       DataHandle$new()
-    }, {
+    },
+    .package = "neuroarchive",
+    {
       read_lna("somefile.h5", run_id = "run-*", allow_plugins = "prompt", validate = TRUE,
                output_dtype = "float64", lazy = FALSE)
     }

--- a/tests/testthat/test-core_read.R
+++ b/tests/testthat/test-core_read.R
@@ -39,6 +39,7 @@ test_that("core_read closes file if invert_step errors", {
       captured_h5 <<- handle$h5
       stop("mock error")
     },
+    .package = "neuroarchive",
     expect_error(core_read(tmp), "mock error")
   )
   expect_true(inherits(captured_h5, "H5File"))
@@ -73,6 +74,7 @@ test_that("core_read allows float16 when support present", {
 
   with_mocked_bindings(
     has_float16_support = function() TRUE,
+    .package = "neuroarchive",
     {
       h <- core_read(tmp, output_dtype = "float16")
       expect_equal(h$meta$output_dtype, "float16")
@@ -96,6 +98,7 @@ test_that("core_read validate=TRUE calls validate_lna", {
   called <- FALSE
   with_mocked_bindings(
     validate_lna = function(file) { called <<- TRUE },
+    .package = "neuroarchive",
     { core_read(tmp, validate = TRUE) }
   )
   expect_true(called)
@@ -190,7 +193,9 @@ test_that("core_read run_id globbing returns handles", {
       root <- handle$h5[["/"]]
       val <- h5_read(root, path)
       handle$update_stash(keys = character(), new_values = list(input = val))
-    }, {
+    },
+    .package = "neuroarchive",
+    {
       res <- core_read(tmp, run_id = "run-0*")
     }
   )
@@ -218,7 +223,9 @@ test_that("core_read run_id globbing lazy returns first", {
       root <- handle$h5[["/"]]
       val <- h5_read(root, path)
       handle$update_stash(keys = character(), new_values = list(input = val))
-    }, {
+    },
+    .package = "neuroarchive",
+    {
       expect_warning(h <- core_read(tmp, run_id = "run-*", lazy = TRUE), "first match")
     }
   )
@@ -239,6 +246,7 @@ test_that("core_read validate=TRUE checks dataset existence", {
 
   with_mocked_bindings(
     invert_step.dummy = function(type, desc, handle) handle,
+    .package = "neuroarchive",
     {
       expect_error(core_read(tmp, validate = TRUE),
                    class = "lna_error_missing_path")

--- a/tests/testthat/test-core_write.R
+++ b/tests/testthat/test-core_write.R
@@ -38,7 +38,9 @@ test_that("transform_params merging honors precedence and deep merge", {
   with_mocked_bindings(
     default_params = function(type) {
       list(a = 1, b = 2, nested = list(x = 0, y = 0))
-    }, {
+    },
+    .package = "neuroarchive",
+    {
       res <- core_write(
         x = array(1, dim = c(1, 1, 1)),
         transforms = c("tB"),

--- a/tests/testthat/test-reader.R
+++ b/tests/testthat/test-reader.R
@@ -38,6 +38,7 @@ test_that("lna_reader initialize closes file on failure", {
         captured_h5 <<- orig_open_h5(file, mode)
         captured_h5
       },
+      .package = "neuroarchive",
       read_lna(tmp, run_id = "run-01", lazy = TRUE)
     ),
     class = "lna_error_run_id"
@@ -129,6 +130,7 @@ test_that("lna_reader$data allow_plugins='prompt' falls back when non-interactiv
   reader <- read_lna(tmp, lazy = TRUE, allow_plugins = "prompt")
   with_mocked_bindings(
     rlang::is_interactive = function() FALSE,
+    .package = "rlang",
     { expect_warning(reader$data(), "Missing invert_step") }
   )
   reader$close()
@@ -141,6 +143,7 @@ test_that("lna_reader$data allow_plugins='prompt' interactive respects choice", 
   with_mocked_bindings(
     rlang::is_interactive = function() TRUE,
     readline = function(prompt = "") "n",
+    .package = "rlang",
     { expect_error(reader$data(), class = "lna_error_no_method") }
   )
   reader$close()
@@ -149,6 +152,7 @@ test_that("lna_reader$data allow_plugins='prompt' interactive respects choice", 
   with_mocked_bindings(
     rlang::is_interactive = function() TRUE,
     readline = function(prompt = "") "y",
+    .package = "rlang",
     { expect_warning(reader$data(), "Missing invert_step") }
   )
   reader$close()

--- a/tests/testthat/test-utils_float16.R
+++ b/tests/testthat/test-utils_float16.R
@@ -11,6 +11,7 @@ test_that("has_float16_support returns logical scalar", {
 test_that("has_float16_support detects packages", {
   with_mocked_bindings(
     requireNamespace = function(pkg, quietly = TRUE) TRUE,
+    .package = "neuroarchive",
     {
       expect_true(has_float16_support())
     }


### PR DESCRIPTION
## Summary
- specify `.package` for mocked bindings in several tests
- keep `rlang` package when mocking `is_interactive`

## Testing
- `./run-tests.sh` *(fails: R is not installed)*