### PR TITLE
Fix create_dataset arg names

### DIFF
--- a/R/utils_json.R
+++ b/R/utils_json.R
@@ -121,7 +121,7 @@ write_json_descriptor <- function(h5_group, name, desc_list) {
   dset <- h5_group$create_dataset(name,
                                   dtype = str_type,
                                   space = space,
-                                  chunk_dim = NULL)
+                                  chunk_dims = NULL)
 
   # Write data using slice assignment
   dset[] <- json_string

--- a/tests/testthat/test-discover.R
+++ b/tests/testthat/test-discover.R
@@ -19,7 +19,7 @@ create_dummy_transforms_in_group <- function(h5_group, transform_names) {
       dset <- NULL
       tryCatch({
         # Create scalar integer dataset, preventing chunking
-        dset <- h5_group$create_dataset(name, dtype = dtype, space = space, chunk_dim = NULL)
+        dset <- h5_group$create_dataset(name, dtype = dtype, space = space, chunk_dims = NULL)
         # Write dummy data using slice assignment
         dset[] <- 0L
       }, finally = {


### PR DESCRIPTION
## Summary
- fix argument name in `write_json_descriptor`
- fix test helper in `test-discover.R`

## Testing
- `./run-tests.sh` *(fails: R not installed)*