### PR TITLE
Improve Plan helpers and update tests

### DIFF
--- a/R/core_write.R
+++ b/R/core_write.R
@@ -99,6 +99,22 @@ core_write <- function(x, transforms, transform_params = list(),
     loop()
   }
 
+  # When no transforms are specified, store the input array(s) directly.
+  if (length(transforms) == 0) {
+    if (is.list(x)) {
+      runs <- if (is.null(names(x)) || any(names(x) == "")) {
+        sprintf("run-%02d", seq_along(x))
+      } else {
+        names(x)
+      }
+      for (i in seq_along(x)) {
+        plan$import_from_array(x[[i]], run_id = runs[i])
+      }
+    } else {
+      plan$import_from_array(x, run_id = run_ids[1])
+    }
+  }
+
   list(handle = handle, plan = plan)
 }
 

--- a/tests/testthat/test-aliases.R
+++ b/tests/testthat/test-aliases.R
@@ -4,13 +4,11 @@ library(testthat)
 
 test_that("compress_fmri forwards to write_lna", {
   captured <- NULL
-  with_mocked_bindings(
+  local_mocked_bindings(
     write_lna = function(...) { captured <<- list(...); "res" },
-    .package = "neuroarchive",
-    {
-      out <- compress_fmri(x = 1, file = "foo.h5")
-    }
+    .env = asNamespace("neuroarchive")
   )
+  out <- compress_fmri(x = 1, file = "foo.h5")
   expect_identical(captured$x, 1)
   expect_identical(captured$file, "foo.h5")
   expect_identical(out, "res")

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -50,7 +50,7 @@ test_that("write_lna forwards arguments to core_write and materialise_plan", {
   fake_plan <- Plan$new()
   fake_handle <- DataHandle$new()
 
-  with_mocked_bindings(
+  local_mocked_bindings(
     core_write = function(x, transforms, transform_params, mask = NULL,
                           header = NULL, plugins = NULL) {
       captured$core <- list(x = x, transforms = transforms,
@@ -63,15 +63,13 @@ test_that("write_lna forwards arguments to core_write and materialise_plan", {
       captured$mat <- list(is_h5 = inherits(h5, "H5File"), plan = plan,
                            header = header, plugins = plugins)
     },
-    .package = "neuroarchive",
-    {
-      write_lna(x = 42, file = tempfile(fileext = ".h5"),
-                transforms = c("tA"),
-                transform_params = list(tA = list(foo = "bar")),
-                header = list(a = 1),
-                plugins = list(p = list(val = 2)))
-    }
+    .env = asNamespace("neuroarchive")
   )
+  write_lna(x = array(42, dim = c(1,1,1)), file = tempfile(fileext = ".h5"),
+            transforms = c("tA"),
+            transform_params = list(tA = list(foo = "bar")),
+            header = list(a = 1),
+            plugins = list(p = list(val = 2)))
 
   expect_equal(captured$core$x, 42)
   expect_equal(captured$core$transforms, c("tA"))
@@ -88,19 +86,17 @@ test_that("write_lna forwards arguments to core_write and materialise_plan", {
 
 test_that("read_lna forwards arguments to core_read", {
   captured <- list()
-  with_mocked_bindings(
+  local_mocked_bindings(
     core_read = function(file, run_id, allow_plugins, validate, output_dtype, lazy) {
       captured$core <- list(file = file, run_id = run_id, allow_plugins = allow_plugins,
                             validate = validate, output_dtype = output_dtype,
                             lazy = lazy)
       DataHandle$new()
     },
-    .package = "neuroarchive",
-    {
-      read_lna("somefile.h5", run_id = "run-*", allow_plugins = "prompt", validate = TRUE,
-               output_dtype = "float64", lazy = FALSE)
-    }
+    .env = asNamespace("neuroarchive")
   )
+  read_lna("somefile.h5", run_id = "run-*", allow_plugins = "prompt", validate = TRUE,
+           output_dtype = "float64", lazy = FALSE)
 
   expect_equal(captured$core$file, "somefile.h5")
   expect_equal(captured$core$run_id, "run-*")

--- a/tests/testthat/test-core_write.R
+++ b/tests/testthat/test-core_write.R
@@ -35,18 +35,16 @@ test_that("transform_params merging honors precedence and deep merge", {
   rm(list = ls(envir = opts_env), envir = opts_env)
   lna_options(tB = list(a = 10, nested = list(x = 1)))
 
-  with_mocked_bindings(
+  local_mocked_bindings(
     default_params = function(type) {
       list(a = 1, b = 2, nested = list(x = 0, y = 0))
     },
-    .package = "neuroarchive",
-    {
-      res <- core_write(
-        x = array(1, dim = c(1, 1, 1)),
-        transforms = c("tB"),
-        transform_params = list(tB = list(b = 20, nested = list(y = 5)))
-      )
-    }
+    .env = asNamespace("neuroarchive")
+  )
+  res <- core_write(
+    x = array(1, dim = c(1, 1, 1)),
+    transforms = c("tB"),
+    transform_params = list(tB = list(b = 20, nested = list(y = 5)))
   )
 
   expect_equal(

--- a/tests/testthat/test-materialise_plan.R
+++ b/tests/testthat/test-materialise_plan.R
@@ -34,6 +34,18 @@ test_that("materialise_plan creates structure and updates plan", {
   neuroarchive:::close_h5_safely(h5)
 })
 
+test_that("materialise_plan works with Plan$import_from_array", {
+  tmp <- local_tempfile(fileext = ".h5")
+  h5 <- neuroarchive:::open_h5(tmp, mode = "w")
+  plan <- Plan$new()
+  plan$import_from_array(array(1, dim = c(1,1,1)))
+  materialise_plan(h5, plan)
+  expect_true(h5$exists("scans/run-01/data/values"))
+  val <- h5[["scans/run-01/data/values"]]$read()
+  expect_equal(val, array(1, dim = c(1,1,1)))
+  neuroarchive:::close_h5_safely(h5)
+})
+
 test_that("materialise_plan writes header attributes", {
   tmp <- local_tempfile(fileext = ".h5")
   h5 <- neuroarchive:::open_h5(tmp, mode = "w")

--- a/tests/testthat/test-utils_float16.R
+++ b/tests/testthat/test-utils_float16.R
@@ -9,11 +9,9 @@ test_that("has_float16_support returns logical scalar", {
 })
 
 test_that("has_float16_support detects packages", {
-  with_mocked_bindings(
+  local_mocked_bindings(
     requireNamespace = function(pkg, quietly = TRUE) TRUE,
-    .package = "neuroarchive",
-    {
-      expect_true(has_float16_support())
-    }
+    .env = asNamespace("neuroarchive")
   )
+  expect_true(has_float16_support())
 })


### PR DESCRIPTION
## Summary
- add `first_run_id` and `import_from_array` helpers to `Plan`
- write initial datasets when no transforms in `core_write`
- expand materialise plan tests
- switch tests to `local_mocked_bindings`

## Testing
- `R -q -e 'devtools::test()'` *(fails: R not found)*