### PR TITLE
Fix handle propagation in core_read

### DIFF
--- a/R/core_read.R
+++ b/R/core_read.R
@@ -122,8 +122,8 @@ core_read <- function(file, run_id = NULL,
           type <- transforms$type[[i]]
           step_idx <- transforms$index[[i]]
           desc <- read_json_descriptor(tf_group, name)
-     
-          handle <- run_transform_step("invert", type, desc, handle, step_idx)
+
+          h <- run_transform_step("invert", type, desc, h, step_idx)
           if (validate) runtime_validate_step(type, desc, h5)
 
 


### PR DESCRIPTION
## Summary
- ensure transform steps update and return the data handle in `core_read`

## Testing
- `This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`