### PR TITLE
Fix syntax in temporal transform test

### DIFF
--- a/tests/testthat/test-transform_temporal.R
+++ b/tests/testthat/test-transform_temporal.R
@@ -65,7 +65,7 @@ test_that("temporal transform rejects unsupported kind", {
     class = "lna_error_validation",
     regexp = "temporal kind"
   )
-}
+})
           
 test_that("temporal transform dpss roundtrip", {
   set.seed(1)


### PR DESCRIPTION
## Summary
- fix missing parenthesis in `test-transform_temporal.R`

## Testing
- `./run-tests.sh` *(fails: R is not installed)*