### PR TITLE
Fix wavelet filter alias

### DIFF
--- a/R/transform_temporal.R
+++ b/R/transform_temporal.R
@@ -200,6 +200,16 @@ invert_step.temporal <- function(type, desc, handle) {
               .subclass = "lna_error_validation",
               location = ".wavelet_basis")
   }
+  # Map common aliases (e.g., "db4") to names expected by `wavelets::dwt`
+  if (is.character(wavelet)) {
+    wl <- tolower(wavelet)
+    if (wl == "db1") {
+      wl <- "haar"
+    } else if (grepl("^db[0-9]+$", wl)) {
+      wl <- sub("^db", "d", wl)
+    }
+    wavelet <- wl
+  }
   J <- log2(n_time)
   dwt_single <- function(x) {
     w <- wavelets::dwt(x, filter = wavelet, n.levels = J, boundary = "periodic")


### PR DESCRIPTION
## Summary
- map common aliases such as `db4` to the filter names expected by the `wavelets` package

## Testing
- `./run-tests.sh` *(fails: R is not installed)*