### PR TITLE
Implement sparsepca whitening & seed support

### DIFF
--- a/R/handle.R
+++ b/R/handle.R
@@ -155,6 +155,25 @@ DataHandle <- R6::R6Class("DataHandle",
     has_key = function(key) {
       stopifnot(is.character(key), length(key) == 1)
       return(key %in% names(self$stash))
+    },
+
+    #' @description
+    #' Return the first available value for a set of candidate keys.
+    #' @param keys Character vector of keys to search for in order.
+    #' @return List with elements `value` and `key` giving the retrieved
+    #'   object and the key that was found.
+    pull_first = function(keys) {
+      stopifnot(is.character(keys), length(keys) > 0)
+      for (k in keys) {
+        if (self$has_key(k)) {
+          return(list(value = self$stash[[k]], key = k))
+        }
+      }
+      abort_lna(
+        paste0("None of the candidate keys found: ", paste(keys, collapse = ", ")),
+        .subclass = "lna_error_contract",
+        location = "DataHandle$pull_first"
+      )
     }
   )
 )

--- a/R/transform_sparsepca.R
+++ b/R/transform_sparsepca.R
@@ -3,41 +3,54 @@
 #' Performs a sparse PCA on the input matrix. If the optional `sparsepca`
 #' package is available, the transform uses `sparsepca::spca()` to compute
 #' sparse loadings. Otherwise it falls back to a truncated SVD via `irlba`
-#' (or base `svd`). This example demonstrates how an external plugin transform
-#' might integrate with the LNA pipeline.
+#' (or base `svd`). Columns may be optionally whitened prior to fitting.
+#' The chosen backend and singular values are recorded for later use.
 #' @keywords internal
 forward_step.myorg.sparsepca <- function(type, desc, handle) {
   p <- desc$params %||% list()
   k <- p$k %||% 2
   alpha <- p$alpha %||% 0.001
   storage_order <- p$storage_order %||% "component_x_voxel"
+  whiten <- p$whiten %||% FALSE
+  seed <- p$seed
 
-  input_key <- if (handle$has_key("aggregated_matrix")) {
-    "aggregated_matrix"
-  } else if (handle$has_key("dense_mat")) {
-    "dense_mat"
-  } else {
-    "input"
-  }
-  X <- handle$get_inputs(input_key)[[1]]
+  inp <- handle$pull_first(c("aggregated_matrix", "dense_mat", "input"))
+  input_key <- inp$key
+  X <- inp$value
   if (!is.matrix(X)) {
     X <- as.matrix(X)
   }
+  if (isTRUE(whiten)) {
+    X <- scale(X, center = TRUE, scale = TRUE)
+  }
+  if (!is.null(seed)) {
+    set.seed(seed)
+  }
 
   if (requireNamespace("sparsepca", quietly = TRUE)) {
+    backend <- "sparsepca"
     fit <- sparsepca::spca(X, k = as.integer(k), alpha = alpha,
                            verbose = FALSE)
     basis <- fit$loadings
     embed <- fit$scores
+    d <- svd(X, nu = 0, nv = 0)$d[seq_len(k)]
   } else if (requireNamespace("irlba", quietly = TRUE)) {
+    backend <- "irlba"
     fit <- irlba::irlba(X, nv = as.integer(k))
     basis <- fit$v
-    embed <- fit$u %*% diag(fit$d)
+    embed <- fit$u
+    d <- fit$d
   } else {
+    backend <- "svd"
     sv <- svd(X, nu = as.integer(k), nv = as.integer(k))
     basis <- sv$v
-    embed <- sv$u %*% diag(sv$d[seq_len(k)])
+    embed <- sv$u
+    d <- sv$d[seq_len(k)]
   }
+  if (!is.null(handle$logger)) {
+    handle$logger$info(sprintf("sparsepca backend: %s", backend))
+  }
+  embed <- embed %*% diag(d)
 
   if (identical(storage_order, "voxel_x_component")) {
     basis <- Matrix::t(basis)
@@ -47,6 +60,7 @@ forward_step.myorg.sparsepca <- function(type, desc, handle) {
   fname <- plan$get_next_filename(type)
   base <- tools::file_path_sans_ext(fname)
   basis_path <- paste0("/basis/", base, "/basis")
+  d_path <- paste0("/basis/", base, "/singular_values")
   run_id <- handle$current_run_id %||% "run-01"
   run_id <- sanitize_run_id(run_id)
   embed_path <- paste0("/scans/", run_id, "/", base, "/embedding")
@@ -56,7 +70,9 @@ forward_step.myorg.sparsepca <- function(type, desc, handle) {
   desc$inputs <- c(input_key)
   desc$outputs <- c("sparsepca_basis", "sparsepca_embedding")
   desc$datasets <- list(list(path = basis_path, role = "basis_matrix"),
-                        list(path = embed_path, role = "coefficients"))
+                        list(path = embed_path, role = "coefficients"),
+                        list(path = d_path, role = "singular_values"))
+  desc$params <- p
   plan$add_descriptor(fname, desc)
 
   plan$add_payload(basis_path, basis)
@@ -67,6 +83,10 @@ forward_step.myorg.sparsepca <- function(type, desc, handle) {
   plan$add_dataset_def(embed_path, "coefficients", as.character(type),
                        handle$plan$origin_label, as.integer(plan$next_index - 1),
                        params_json, embed_path, "eager")
+  plan$add_payload(d_path, d)
+  plan$add_dataset_def(d_path, "singular_values", as.character(type),
+                       handle$plan$origin_label, as.integer(plan$next_index - 1),
+                       params_json, d_path, "eager")
 
   handle$plan <- plan
   # Stash the actual basis and embedding, not just TRUE/FALSE flags
@@ -85,14 +105,21 @@ invert_step.myorg.sparsepca <- function(type, desc, handle) {
   ds <- desc$datasets
   basis_path <- ds[[which(vapply(ds, function(d) d$role, character(1)) == "basis_matrix")]]$path
   embed_path <- ds[[which(vapply(ds, function(d) d$role, character(1)) == "coefficients")]]$path
+  d_idx <- which(vapply(ds, function(d) d$role, character(1)) == "singular_values")
+  d_path <- if (length(d_idx) == 1) ds[[d_idx]]$path else NULL
 
   root <- handle$h5[["/"]]
   basis <- h5_read(root, basis_path)
   embed <- h5_read(root, embed_path)
+  d <- if (!is.null(d_path)) h5_read(root, d_path) else NULL
   p <- desc$params %||% list()
   storage_order <- p$storage_order %||% "component_x_voxel"
   if (identical(storage_order, "voxel_x_component")) {
     basis <- Matrix::t(basis)
+  }
+
+  if (!is.null(d) && ncol(embed) == length(d)) {
+    embed <- embed %*% diag(d)
   }
 
   Xhat <- embed %*% basis
@@ -114,5 +141,6 @@ invert_step.myorg.sparsepca <- function(type, desc, handle) {
 #' @export
 #' @keywords internal
 lna_default.myorg.sparsepca <- function() {
-  list(k = 50L, alpha = 1e-3, whiten = FALSE, storage_order = "component_x_voxel")
+  list(k = 50L, alpha = 1e-3, whiten = FALSE, seed = 42L,
+       storage_order = "component_x_voxel")
 }

--- a/inst/schemas/myorg.sparsepca.schema.json
+++ b/inst/schemas/myorg.sparsepca.schema.json
@@ -7,6 +7,7 @@
     "k": {"type": "integer", "minimum": 1, "default": 50},
     "alpha": {"type": "number", "default": 0.001},
     "whiten": {"type": "boolean", "default": false},
+    "seed": {"type": "integer", "default": 42},
     "storage_order": {
       "type": "string",
       "enum": ["component_x_voxel", "voxel_x_component"],

--- a/man/forward_step.myorg.sparsepca.Rd
+++ b/man/forward_step.myorg.sparsepca.Rd
@@ -10,7 +10,7 @@
 Performs a sparse PCA on the input matrix. If the optional `sparsepca`
 package is available, the transform uses `sparsepca::spca()` to compute
 sparse loadings. Otherwise it falls back to a truncated SVD via `irlba`
-(or base `svd`). This example demonstrates how an external plugin transform
-might integrate with the LNA pipeline.
+(or base `svd`). Columns can be whitened prior to fitting and the
+singular values of the fit are saved alongside the basis.
 }
 \keyword{internal}

--- a/man/invert_step.myorg.sparsepca.Rd
+++ b/man/invert_step.myorg.sparsepca.Rd
@@ -8,5 +8,8 @@
 }
 \description{
 Reconstructs data from the sparse PCA coefficients and basis matrix.
+If singular values were written during the forward step they are
+applied before multiplying by the basis. The basis may be transposed
+when `storage_order = "voxel_x_component"`.
 }
 \keyword{internal}

--- a/man/lna_default.myorg.sparsepca.Rd
+++ b/man/lna_default.myorg.sparsepca.Rd
@@ -7,6 +7,7 @@
 lna_default.myorg.sparsepca()
 }
 \description{
-Default parameters for myorg.sparsepca
+Default parameters for myorg.sparsepca including a default seed for
+reproducibility.
 }
 \keyword{internal}

--- a/tests/testthat/test-handle.R
+++ b/tests/testthat/test-handle.R
@@ -116,6 +116,14 @@ test_that("DataHandle get_inputs works correctly", {
   expect_error(h$get_inputs(character(0))) # Empty vector
 })
 
+test_that("DataHandle pull_first retrieves first available", {
+  h <- DataHandle$new(initial_stash = list(a = 1, b = 2))
+  res <- h$pull_first(c("c", "b", "a"))
+  expect_equal(res$key, "b")
+  expect_equal(res$value, 2)
+  expect_error(h$pull_first(c("x", "y")), class = "lna_error_contract")
+})
+
 test_that("DataHandle with method provides immutability", {
   # Initial object
   h1_stash <- list(a = 1)

--- a/tests/testthat/test-transform_sparsepca.R
+++ b/tests/testthat/test-transform_sparsepca.R
@@ -10,6 +10,7 @@ test_that("default_params for myorg.sparsepca loads schema", {
   expect_equal(p$alpha, 0.001)
   expect_identical(p$whiten, FALSE)
   expect_equal(p$storage_order, "component_x_voxel")
+  expect_equal(p$seed, 42)
 })
 
 
@@ -24,4 +25,48 @@ test_that("sparsepca forward and inverse roundtrip", {
   out <- h$stash$input
   expect_equal(dim(out), dim(X))
   expect_equal(out, X, tolerance = 1e-6)
+})
+
+test_that("whitening centers and scales the matrix", {
+  set.seed(1)
+  X <- matrix(rnorm(60), nrow = 15)
+  plan <- Plan$new()
+  h <- DataHandle$new(initial_stash = list(input = X), plan = plan)
+  desc <- list(type = "myorg.sparsepca", params = list(k = 3, whiten = TRUE))
+  h2 <- neuroarchive:::forward_step.myorg.sparsepca("myorg.sparsepca", desc, h)
+  B <- h2$stash$sparsepca_basis
+  E <- h2$stash$sparsepca_embedding
+  if (identical(desc$params$storage_order %||% "component_x_voxel", "component_x_voxel")) {
+    B <- t(B)
+  }
+  Xw <- E %*% B
+  expect_true(all(abs(colMeans(Xw)) < 1e-6))
+  expect_true(all(abs(apply(Xw, 2, sd) - 1) < 1e-6))
+})
+
+test_that("seed parameter yields deterministic results", {
+  set.seed(2)
+  X <- matrix(rnorm(40), nrow = 10)
+  plan1 <- Plan$new(); plan2 <- Plan$new()
+  desc <- list(type = "myorg.sparsepca", params = list(k = 2, seed = 123))
+  h1 <- DataHandle$new(initial_stash = list(input = X), plan = plan1)
+  h2 <- DataHandle$new(initial_stash = list(input = X), plan = plan2)
+  r1 <- neuroarchive:::forward_step.myorg.sparsepca("myorg.sparsepca", desc, h1)
+  r2 <- neuroarchive:::forward_step.myorg.sparsepca("myorg.sparsepca", desc, h2)
+  expect_equal(r1$stash$sparsepca_basis, r2$stash$sparsepca_basis)
+  expect_equal(r1$stash$sparsepca_embedding, r2$stash$sparsepca_embedding)
+})
+
+test_that("singular values dataset is written", {
+  set.seed(3)
+  X <- matrix(rnorm(40), nrow = 10)
+  tmp <- local_tempfile(fileext = ".h5")
+  res <- write_lna(X, file = tmp, transforms = "myorg.sparsepca",
+                   transform_params = list(`myorg.sparsepca` = list(k = 2)))
+  sv_idx <- which(res$plan$datasets$role == "singular_values")
+  expect_length(sv_idx, 1)
+  h5 <- hdf5r::H5File$new(tmp, mode = "r")
+  vals <- h5[[res$plan$datasets$path[[sv_idx]]]]$read()
+  expect_length(vals, 2)
+  h5$close_all()
 })


### PR DESCRIPTION
## Summary
- extend `DataHandle` with `pull_first`
- enhance sparse PCA transform with whitening, deterministic seed, logging and singular value output
- read singular values on inversion
- add default seed
- update schema and docs
- expand unit tests

## Testing
- `./run-tests.sh`