### PR TITLE
docs: expand S1-2 storage details

### DIFF
--- a/raw-data/Quantization_proposal_and_sprint.md
+++ b/raw-data/Quantization_proposal_and_sprint.md
@@ -102,6 +102,8 @@ Input: Data $X$ (from `DataHandle$stash`), parameters from `desc$params`.
 6.  **Data Storage:**
     *   Determine narrowest unsigned integer type: `storage_type_str = if (bits <= 8) "uint8" else "uint16"`.
     *   Convert $Q(X)$ to this integer type before writing.
+    *   Pass `storage_type_str` to `h5_write_dataset()` so the dataset uses the matching HDF5 type
+        (`H5T_STD_U8LE` or `H5T_STD_U16LE`).
     *   **HDF5 Datasets:**
         *   `/scans/{run_id}/quant_data/{transform_basename}/quantized_values`: Stores $Q(X)$ as `storage_type_str`.
             *   **Attribute:** Attach `quant_bits = bits` (integer) to this dataset using `lna:::h5_attr_write()`.


### PR DESCRIPTION
## Summary
- document how `forward_step.quant` passes `storage_type_str` to `h5_write_dataset`
- specify the associated HDF5 integer types for uint8/uint16 storage

## Testing
- `./run-tests.sh` *(fails: R is not installed)*