### PR TITLE
Implement QNT-S1-4

### DIFF
--- a/tests/testthat/test-transform_quant.R
+++ b/tests/testthat/test-transform_quant.R
@@ -133,3 +133,10 @@ test_that("quant transform errors on non-finite input", {
   )
 
 })
+
+test_that("invert_step.quant warns when quant_bits attribute missing", {
+  arr <- array(runif(6), dim = c(2,3))
+  tmp <- local_tempfile(fileext = ".h5")
+  write_lna(arr, file = tmp, transforms = "quant")
+  expect_warning(read_lna(tmp), regexp = "quant_bits")
+})


### PR DESCRIPTION
## Summary
- read `quant_bits` attribute when inverting the quant transform
- warn and fall back to descriptor value if the attribute is missing
- test warning behaviour for missing `quant_bits` attribute

## Testing
- `./run-tests.sh` *(fails: R is not installed)*