### PR TITLE
Implement QNT-S1-2 narrow integer storage

### DIFF
--- a/R/core_write.R
+++ b/R/core_write.R
@@ -158,7 +158,8 @@ core_write <- function(x, transforms, transform_params = list(),
         step_index = 0L,
         params_json = "{}",
         payload_key = payload_key,
-        write_mode = "eager"
+        write_mode = "eager",
+        dtype = NA_character_
       )
     }
 

--- a/R/materialise.R
+++ b/R/materialise.R
@@ -98,14 +98,14 @@ materialise_plan <- function(h5, plan, checksum = c("none", "sha256"),
   }
 
   # Helper to write a single payload dataset with retries
-  write_payload <- function(path, data, step_index) {
+  write_payload <- function(path, data, step_index, dtype_str = NA_character_) {
     comp_level <- lna_options("write.compression_level")[[1]]
     if (is.null(comp_level)) comp_level <- 0
     chunk_dims <- NULL
 
     attempt <- function(level, chunks) {
       h5_write_dataset(root, path, data, chunk_dims = chunks,
-                       compression_level = level)
+                       compression_level = level, dtype = dtype_str)
       NULL
     }
 
@@ -121,12 +121,12 @@ materialise_plan <- function(h5, plan, checksum = c("none", "sha256"),
 
 
     # Determine datatype size for chunk heuristics
-    dtype <- guess_h5_type(data)
+    dtype <- if (!is.na(dtype_str)) map_dtype(dtype_str) else guess_h5_type(data)
     dtype_size <- dtype$get_size(variable_as_inf = FALSE)
     if (!is.finite(dtype_size) || dtype_size <= 0) {
       dtype_size <- 1L
     }
-    if (inherits(dtype, "H5T")) dtype$close()
+    if (inherits(dtype, "H5T") && is.na(dtype_str)) dtype$close()
     cdims <- if (is.null(chunk_dims)) guess_chunk_dims(dim(data), dtype_size) else as.integer(chunk_dims)
 
     if (inherits(res, "error")) {
@@ -178,7 +178,7 @@ materialise_plan <- function(h5, plan, checksum = c("none", "sha256"),
           next
         }
         if (!is.null(p)) p(message = row$path)
-        write_payload(row$path, payload, row$step_index)
+        write_payload(row$path, payload, row$step_index, row$dtype)
         plan$datasets$write_mode_effective[i] <- "eager"
         plan$mark_payload_written(key)
       }

--- a/R/plan.R
+++ b/R/plan.R
@@ -34,7 +34,8 @@ Plan <- R6::R6Class("Plan",
         params_json = character(),
         payload_key = character(),
         write_mode = character(),
-        write_mode_effective = character() # Added based on Spec v1.4
+        write_mode_effective = character(), # Added based on Spec v1.4
+        dtype = character()
       )
       self$descriptors <- list()
       self$payloads <- list()
@@ -69,7 +70,9 @@ Plan <- R6::R6Class("Plan",
     #' @param params_json Character string, JSON representation of transform params.
     #' @param payload_key Character string, key linking to the entry in `self$payloads`.
     #' @param write_mode Character string, requested write mode ("eager"/"stream").
-    add_dataset_def = function(path, role, producer, origin, step_index, params_json, payload_key, write_mode) {
+    #' @param dtype Optional character string naming the storage datatype (e.g.,
+    #'   "uint8", "uint16").
+    add_dataset_def = function(path, role, producer, origin, step_index, params_json, payload_key, write_mode, dtype = NA_character_) {
       # Basic type checks with additional validation
       stopifnot(
         is.character(path), length(path) == 1,
@@ -79,7 +82,8 @@ Plan <- R6::R6Class("Plan",
         is.numeric(step_index), length(step_index) == 1, !is.na(step_index), step_index %% 1 == 0,
         is.character(params_json), length(params_json) == 1,
         is.character(payload_key), length(payload_key) == 1,
-        is.character(write_mode), length(write_mode) == 1
+        is.character(write_mode), length(write_mode) == 1,
+        is.character(dtype), length(dtype) == 1
       )
 
       # Validate write_mode values
@@ -103,7 +107,8 @@ Plan <- R6::R6Class("Plan",
         params_json = params_json,
         payload_key = payload_key,
         write_mode = write_mode,
-        write_mode_effective = NA_character_ # To be filled during materialization
+        write_mode_effective = NA_character_, # To be filled during materialization
+        dtype = as.character(dtype)
       )
       invisible(self)
     },
@@ -192,7 +197,8 @@ Plan <- R6::R6Class("Plan",
         step_index = 0L,
         params_json = "{}",
         payload_key = key,
-        write_mode = "eager"
+        write_mode = "eager",
+        dtype = NA_character_
       )
       invisible(self)
     },

--- a/R/transform_basis.R
+++ b/R/transform_basis.R
@@ -191,18 +191,18 @@ forward_step.basis <- function(type, desc, handle) {
   plan$add_payload(matrix_path, basis_mat)
   plan$add_dataset_def(matrix_path, "basis_matrix", type,
                        plan$origin_label, as.integer(step_index),
-                       params_json, matrix_path, "eager")
+                       params_json, matrix_path, "eager", dtype = NA_character_)
   if (!is.null(mean_vec)) {
     plan$add_payload(center_path, mean_vec)
     plan$add_dataset_def(center_path, "center", type,
                          plan$origin_label, as.integer(step_index),
-                         params_json, center_path, "eager")
+                         params_json, center_path, "eager", dtype = NA_character_)
   }
   if (!is.null(scale_vec)) {
     plan$add_payload(scale_path, scale_vec)
     plan$add_dataset_def(scale_path, "scale", type,
                          plan$origin_label, as.integer(step_index),
-                         params_json, scale_path, "eager")
+                         params_json, scale_path, "eager", dtype = NA_character_)
   }
 
   handle$plan <- plan

--- a/R/transform_delta.R
+++ b/R/transform_delta.R
@@ -98,12 +98,12 @@ forward_step.delta <- function(type, desc, handle) {
   plan$add_payload(delta_path, delta_stream)
   plan$add_dataset_def(delta_path, "delta_stream", as.character(type), run_id,
                        as.integer(step_index), params_json,
-                       delta_path, "eager")
+                       delta_path, "eager", dtype = NA_character_)
   if (identical(ref_store, "first_value_verbatim")) {
     plan$add_payload(first_path, first_vals)
     plan$add_dataset_def(first_path, "first_values", as.character(type), run_id,
                          as.integer(step_index), params_json,
-                         first_path, "eager")
+                         first_path, "eager", dtype = NA_character_)
   }
 
   handle$plan <- plan

--- a/R/transform_embed.R
+++ b/R/transform_embed.R
@@ -76,7 +76,7 @@ forward_step.embed <- function(type, desc, handle) {
 
   plan$add_dataset_def(coef_path, "coefficients", as.character(type), run_id,
                        as.integer(step_index), params_json,
-                       coef_path, "eager")
+                       coef_path, "eager", dtype = NA_character_)
 
   handle$plan <- plan
   handle$update_stash(keys = input_key, new_values = list(input = coeff,

--- a/R/transform_quant.R
+++ b/R/transform_quant.R
@@ -64,6 +64,7 @@ forward_step.quant <- function(type, desc, handle) {
   offset <- params$offset
 
   storage.mode(q) <- "integer"
+  storage_type_str <- if (bits <= 8) "uint8" else "uint16"
 
   run_id <- handle$current_run_id %||% "run-01"
   run_id <- sanitize_run_id(run_id)
@@ -79,15 +80,15 @@ forward_step.quant <- function(type, desc, handle) {
   plan$add_payload(data_path, q)
   plan$add_dataset_def(data_path, "quantized", as.character(type), run_id,
                        as.integer(step_index), params_json,
-                       data_path, "eager")
+                       data_path, "eager", dtype = storage_type_str)
   plan$add_payload(scale_path, scale)
   plan$add_dataset_def(scale_path, "scale", as.character(type), run_id,
                        as.integer(step_index), params_json,
-                       scale_path, "eager")
+                       scale_path, "eager", dtype = NA_character_)
   plan$add_payload(offset_path, offset)
   plan$add_dataset_def(offset_path, "offset", as.character(type), run_id,
                        as.integer(step_index), params_json,
-                       offset_path, "eager")
+                       offset_path, "eager", dtype = NA_character_)
 
   handle$plan <- plan
   handle$update_stash(keys = input_key, new_values = list())

--- a/R/transform_sparsepca.R
+++ b/R/transform_sparsepca.R
@@ -97,15 +97,15 @@ forward_step.myorg.sparsepca <- function(type, desc, handle) {
   plan$add_payload(basis_path, basis)
   plan$add_dataset_def(basis_path, "basis_matrix", as.character(type),
                        handle$plan$origin_label, as.integer(plan$next_index - 1),
-                       params_json, basis_path, "eager")
+                       params_json, basis_path, "eager", dtype = NA_character_)
   plan$add_payload(embed_path, embed)
   plan$add_dataset_def(embed_path, "coefficients", as.character(type),
                        handle$plan$origin_label, as.integer(plan$next_index - 1),
-                       params_json, embed_path, "eager")
+                       params_json, embed_path, "eager", dtype = NA_character_)
   plan$add_payload(d_path, d)
   plan$add_dataset_def(d_path, "singular_values", as.character(type),
                        handle$plan$origin_label, as.integer(plan$next_index - 1),
-                       params_json, d_path, "eager")
+                       params_json, d_path, "eager", dtype = NA_character_)
 
   handle$plan <- plan
   # Stash the actual basis and embedding, not just TRUE/FALSE flags

--- a/R/transform_temporal.R
+++ b/R/transform_temporal.R
@@ -103,7 +103,7 @@ forward_step.temporal <- function(type, desc, handle) {
   
   plan$add_dataset_def(basis_path, "temporal_basis", as.character(type), run_id,
                        as.integer(plan$next_index), params_json,
-                       basis_path, "eager")
+                       basis_path, "eager", dtype = NA_character_)
 
   if (!is.null(knots_data)) {
     knots_payload <- knots_data
@@ -113,7 +113,7 @@ forward_step.temporal <- function(type, desc, handle) {
     plan$add_payload(knots_path, knots_payload)
     plan$add_dataset_def(knots_path, "knots", as.character(type), run_id,
                          as.integer(plan$next_index), params_json,
-                         knots_path, "eager")
+                         knots_path, "eager", dtype = NA_character_)
   }
   
   # Prepare coeff_payload for saving (ensure 3D)
@@ -125,7 +125,7 @@ forward_step.temporal <- function(type, desc, handle) {
   
   plan$add_dataset_def(coef_path, "temporal_coefficients", as.character(type), run_id,
                        as.integer(plan$next_index), params_json,
-                       coef_path, "eager")
+                       coef_path, "eager", dtype = NA_character_)
   handle$plan <- plan
 
   handle$update_stash(keys = c(input_key),

--- a/man/Plan.Rd
+++ b/man/Plan.Rd
@@ -92,7 +92,8 @@ Add a definition for an HDF5 dataset.
   step_index,
   params_json,
   payload_key,
-  write_mode
+  write_mode,
+  dtype
 )}\if{html}{\out{</div>}}
 }
 
@@ -114,6 +115,7 @@ Add a definition for an HDF5 dataset.
 \item{\code{payload_key}}{Character string, key linking to the entry in `self$payloads`.}
 
 \item{\code{write_mode}}{Character string, requested write mode ("eager"/"stream").}
+\item{\code{dtype}}{Optional character string naming the storage datatype (e.g., "uint8", "uint16").}
 }
 \if{html}{\out{</div>}}
 }

--- a/tests/testthat/test-core_read.R
+++ b/tests/testthat/test-core_read.R
@@ -251,9 +251,9 @@ test_that("core_read run_id globbing returns handles", {
   plan <- Plan$new()
   plan$add_descriptor("00_dummy.json", list(type = "dummy"))
   plan$add_payload("p1", 1L)
-  plan$add_dataset_def("/scans/run-01/data", "data", "dummy", "run-01", 0L, "{}", "p1", "eager")
+  plan$add_dataset_def("/scans/run-01/data", "data", "dummy", "run-01", 0L, "{}", "p1", "eager", dtype = NA_character_)
   plan$add_payload("p2", 2L)
-  plan$add_dataset_def("/scans/run-02/data", "data", "dummy", "run-02", 0L, "{}", "p2", "eager")
+  plan$add_dataset_def("/scans/run-02/data", "data", "dummy", "run-02", 0L, "{}", "p2", "eager", dtype = NA_character_)
   materialise_plan(h5, plan)
   neuroarchive:::close_h5_safely(h5)
 
@@ -293,9 +293,9 @@ test_that("core_read run_id globbing lazy returns first", {
   plan <- Plan$new()
   plan$add_descriptor("00_dummy.json", list(type = "dummy"))
   plan$add_payload("p1", 1L)
-  plan$add_dataset_def("/scans/run-01/data", "data", "dummy", "run-01", 0L, "{}", "p1", "eager")
+  plan$add_dataset_def("/scans/run-01/data", "data", "dummy", "run-01", 0L, "{}", "p1", "eager", dtype = NA_character_)
   plan$add_payload("p2", 2L)
-  plan$add_dataset_def("/scans/run-02/data", "data", "dummy", "run-02", 0L, "{}", "p2", "eager")
+  plan$add_dataset_def("/scans/run-02/data", "data", "dummy", "run-02", 0L, "{}", "p2", "eager", dtype = NA_character_)
   materialise_plan(h5, plan)
   neuroarchive:::close_h5_safely(h5)
 

--- a/tests/testthat/test-materialise_checksum.R
+++ b/tests/testthat/test-materialise_checksum.R
@@ -14,7 +14,7 @@ test_that("materialise_plan writes sha256 checksum attribute that matches pre-at
     p <- Plan$new()
     p$add_descriptor("00_dummy.json", list(type = "dummy"))
     p$add_payload("payload", matrix(1:4, nrow = 2))
-    p$add_dataset_def("/scans/run-01/data", "data", "dummy", "run-01", 0L, "{}", "payload", "eager")
+    p$add_dataset_def("/scans/run-01/data", "data", "dummy", "run-01", 0L, "{}", "payload", "eager", dtype = NA_character_)
     p
   }
 

--- a/tests/testthat/test-materialise_chunk_retry.R
+++ b/tests/testthat/test-materialise_chunk_retry.R
@@ -92,13 +92,13 @@ test_that("materialise_plan retries with chunk heuristics using local copy", {
   # Need Plan to be the actual Plan object from the package
   plan <- neuroarchive:::Plan$new()
   plan$add_payload("p", matrix(1:10, nrow = 2))
-  plan$add_dataset_def("/scans/run-01/data", "data", "dummy", "run-01", 0L, "{}", "p", "eager")
+  plan$add_dataset_def("/scans/run-01/data", "data", "dummy", "run-01", 0L, "{}", "p", "eager", dtype = NA_character_)
 
   mock_env <- new.env()
   mock_env$calls <- list()
   
   # This is our mock, to be passed to materialise_plan_for_test
-  h5_write_dataset_for_test <- function(h5_group, path, data, chunk_dims = NULL, compression_level = 0) {
+  h5_write_dataset_for_test <- function(h5_group, path, data, chunk_dims = NULL, compression_level = 0, dtype = NULL) {
     mock_env$calls <- c(mock_env$calls, list(chunk_dims)) # New way to append
     
     if (length(mock_env$calls) < 3) {

--- a/tests/testthat/test-materialise_plan.R
+++ b/tests/testthat/test-materialise_plan.R
@@ -10,7 +10,7 @@ test_that("materialise_plan creates structure and updates plan", {
   plan <- Plan$new()
   plan$add_descriptor("00_dummy.json", list(type = "dummy"))
   plan$add_payload("payload", matrix(1:4, nrow = 2))
-  plan$add_dataset_def("/scans/run-01/data", "data", "dummy", "run-01", 0L, "{}", "payload", "eager")
+  plan$add_dataset_def("/scans/run-01/data", "data", "dummy", "run-01", 0L, "{}", "payload", "eager", dtype = NA_character_)
 
   materialise_plan(h5, plan)
 
@@ -69,7 +69,7 @@ test_that("materialise_plan respects progress handlers", {
     key <- paste0("p", i)
     path <- paste0("/scans/run-01/d", i)
     plan$add_payload(key, 1:5)
-    plan$add_dataset_def(path, "data", "dummy", "run-01", 0L, "{}", key, "eager")
+    plan$add_dataset_def(path, "data", "dummy", "run-01", 0L, "{}", key, "eager", dtype = NA_character_)
   }
   
   old_handlers <- progressr::handlers()

--- a/tests/testthat/test-plan.R
+++ b/tests/testthat/test-plan.R
@@ -24,7 +24,8 @@ test_that("Plan initialization works correctly", {
   # Check datasets tibble structure
   expected_cols <- c(
     "path", "role", "producer", "origin", "step_index",
-    "params_json", "payload_key", "write_mode", "write_mode_effective"
+    "params_json", "payload_key", "write_mode", "write_mode_effective",
+    "dtype"
   )
   expect_equal(names(plan$datasets), expected_cols)
   # Check column types (optional but good)
@@ -92,7 +93,8 @@ test_that("Plan add_dataset_def works correctly", {
   plan$add_dataset_def(
     path = def1$path, role = def1$role, producer = def1$producer,
     origin = def1$origin, step_index = def1$step_index, params_json = def1$params_json,
-    payload_key = def1$payload_key, write_mode = def1$write_mode
+    payload_key = def1$payload_key, write_mode = def1$write_mode,
+    dtype = NA_character_
   )
 
   # Check results
@@ -107,28 +109,29 @@ test_that("Plan add_dataset_def works correctly", {
   expect_equal(row1$payload_key, def1$payload_key)
   expect_equal(row1$write_mode, def1$write_mode)
   expect_equal(row1$write_mode_effective, NA_character_)
+  expect_equal(row1$dtype, NA_character_)
 
   # Add another one
-  plan$add_dataset_def("/basis/global", "basis", "pca", "global", 0L, '{"k": 50}', "pca_basis", "eager")
+  plan$add_dataset_def("/basis/global", "basis", "pca", "global", 0L, '{"k": 50}', "pca_basis", "eager", dtype = NA_character_)
   expect_equal(nrow(plan$datasets), 2)
 
   # step_index accepts numeric integer
-  plan$add_dataset_def("/data/extra", "extra", "dummy", "run-01", 1, "{}", "raw_data", "eager")
+  plan$add_dataset_def("/data/extra", "extra", "dummy", "run-01", 1, "{}", "raw_data", "eager", dtype = NA_character_)
   expect_equal(nrow(plan$datasets), 3)
   expect_equal(plan$datasets$step_index[3], 1L)
 
   # invalid step_index (non integer numeric)
-  expect_error(plan$add_dataset_def("/bad", "data", "dummy", "run-01", 1.5, "{}", "raw_data", "eager"))
+  expect_error(plan$add_dataset_def("/bad", "data", "dummy", "run-01", 1.5, "{}", "raw_data", "eager", dtype = NA_character_))
 
   # invalid write_mode
-  expect_error(plan$add_dataset_def("/bad", "data", "dummy", "run-01", 0L, "{}", "raw_data", "invalid"))
+  expect_error(plan$add_dataset_def("/bad", "data", "dummy", "run-01", 0L, "{}", "raw_data", "invalid", dtype = NA_character_))
 
   # invalid JSON
-  expect_error(plan$add_dataset_def("/bad", "data", "dummy", "run-01", 0L, "not json", "raw_data", "eager"))
+  expect_error(plan$add_dataset_def("/bad", "data", "dummy", "run-01", 0L, "not json", "raw_data", "eager", dtype = NA_character_))
 
   # Check some basic type errors handled by stopifnot
-  expect_error(plan$add_dataset_def(path=123, role="", producer="", origin="", step_index=0L, params_json="", payload_key="", write_mode=""))
-  expect_error(plan$add_dataset_def(path="", role="", producer="", origin="", step_index="a", params_json="", payload_key="", write_mode=""))
+  expect_error(plan$add_dataset_def(path=123, role="", producer="", origin="", step_index=0L, params_json="", payload_key="", write_mode="", dtype = NA_character_))
+  expect_error(plan$add_dataset_def(path="", role="", producer="", origin="", step_index="a", params_json="", payload_key="", write_mode="", dtype = NA_character_))
 })
 
 test_that("Plan add_descriptor and get_next_filename work correctly", {

--- a/tests/testthat/test-validate_fork_safety.R
+++ b/tests/testthat/test-validate_fork_safety.R
@@ -8,7 +8,7 @@ create_valid_lna <- function(path, checksum = TRUE) {
   plan$add_descriptor("00_dummy.json", list(type = "dummy"))
   plan$add_payload("payload", matrix(1:4, nrow = 2))
   plan$add_dataset_def("/scans/run-01/data", "data", "dummy", "run-01", 0L, "{}",
-                      "payload", "eager")
+                      "payload", "eager", dtype = NA_character_)
   materialise_plan(h5, plan, checksum = if (checksum) "sha256" else "none")
 }
 

--- a/tests/testthat/test-validate_lna.R
+++ b/tests/testthat/test-validate_lna.R
@@ -9,7 +9,7 @@ create_valid_lna <- function(path, checksum = TRUE) {
   plan$add_descriptor("00_dummy.json", list(type = "dummy"))
   plan$add_payload("payload", matrix(1:4, nrow = 2))
   plan$add_dataset_def("/scans/run-01/data", "data", "dummy", "run-01", 0L, "{}",
-                      "payload", "eager")
+                      "payload", "eager", dtype = NA_character_)
   materialise_plan(h5, plan, checksum = if (checksum) "sha256" else "none")
 }
 


### PR DESCRIPTION
## Summary
- add `dtype` handling in Plan and dataset writer
- store quantized data using uint8/uint16 types
- update materialisation to respect dtype
- document new argument in Plan manual
- adjust tests for updated Plan API

## Testing
- `./run-tests.sh` *(fails: R is not installed)*