### PR TITLE
Implement quant_bits attribute

### DIFF
--- a/R/materialise.R
+++ b/R/materialise.R
@@ -179,6 +179,14 @@ materialise_plan <- function(h5, plan, checksum = c("none", "sha256"),
         }
         if (!is.null(p)) p(message = row$path)
         write_payload(row$path, payload, row$step_index)
+        if (row$producer == "quant" && row$role == "quantized") {
+          bits_val <- tryCatch(jsonlite::fromJSON(row$params_json)$bits,
+                               error = function(e) NULL)
+          bits_val <- bits_val %||% 8L
+          dset_obj <- root[[row$path]]
+          h5_attr_write(dset_obj, "quant_bits", as.integer(bits_val))
+          dset_obj$close()
+        }
         plan$datasets$write_mode_effective[i] <- "eager"
         plan$mark_payload_written(key)
       }


### PR DESCRIPTION
## Summary
- write quant_bits attribute after quantized dataset is written

## Testing
- `bash run-tests.sh` *(fails: R is not installed)*