### PR TITLE
Clarify time dimension orientation

### DIFF
--- a/LatentNeuroArchiveCodingGuide.md
+++ b/LatentNeuroArchiveCodingGuide.md
@@ -8,7 +8,15 @@ Okay, this final feedback targets crucial details for implementation robustness 
 
 **1. Overview & Purpose**
 
+
 (No changes from v1.0 - goals remain the same)
+
+### Data shape convention
+
+Arrays supplied to `write_lna()` should store time in the final
+dimension.  Transforms operate on matrices with time along rows and
+voxels along columns.  Thus a `10×4×1` array is first reshaped to a
+`10×4` matrix before the Sparse PCA step.
 
 **2. Public API**
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ arrays using a sequence of transforms.  The simplest transform is
 `quant`, which performs integer quantisation, but Phase 2 adds
 `basis`/`embed` for PCA-style dimensionality reduction.
 
+Arrays fed to `write_lna()` should have the time dimension last
+(for example `dim = c(nx, ny, nz, nt)` for a 4D volume).  Before a
+transform runs, these arrays are reshaped into a matrix with rows
+corresponding to time points and columns corresponding to voxels.
+For instance a `10×4×1` array becomes a `10×4` matrix prior to
+applying the Sparse PCA transform.
+
 ```r
 library(neuroarchive)
 


### PR DESCRIPTION
## Summary
- document that time is the final axis and transforms operate on time-by-voxel matrices
- give an example conversion of a 10×4×1 array to a 10×4 matrix

## Testing
- `./run-tests.sh` *(fails: R is not installed)*