### PR TITLE
Add quantization storage tests and dtype support

### DIFF
--- a/R/materialise.R
+++ b/R/materialise.R
@@ -179,7 +179,7 @@ materialise_plan <- function(h5, plan, checksum = c("none", "sha256"),
         }
         if (!is.null(p)) p(message = row$path)
 
-        write_payload(row$path, payload, row$step_index)
+        write_payload(row$path, payload, row$step_index, row$dtype)
         if (row$producer == "quant" && row$role == "quantized") {
           bits_val <- tryCatch(jsonlite::fromJSON(row$params_json)$bits,
                                error = function(e) NULL)

--- a/R/transform_quant.R
+++ b/R/transform_quant.R
@@ -132,6 +132,18 @@ invert_step.quant <- function(type, desc, handle) {
   }, finally = {
     if (!is.null(dset) && inherits(dset, "H5D")) dset$close()
   })
+  if (!is.null(desc$params$bits) && !is.na(desc$params$bits)) {
+    if (!is.na(attr_bits) && attr_bits != desc$params$bits) {
+      abort_lna(
+        sprintf(
+          "quant_bits attribute (%s) disagrees with descriptor bits (%s)",
+          attr_bits, desc$params$bits
+        ),
+        .subclass = "lna_error_validation",
+        location = "invert_step.quant:bits"
+      )
+    }
+  }
   scale <- as.numeric(h5_read(root, scale_path))
   offset <- as.numeric(h5_read(root, offset_path))
   x <- q * scale + offset


### PR DESCRIPTION
## Summary
- ensure payload writes respect dataset dtype
- validate quant_bits attribute in `invert_step.quant`
- test quantized dataset storage types and attribute handling

## Testing
- `sh run-tests.sh` *(fails: R not installed)*