### PR TITLE
Implement clipping logic for quant transform

### DIFF
--- a/R/options.R
+++ b/R/options.R
@@ -31,6 +31,8 @@ lna_options_env <- new.env(parent = emptyenv())
 default_opts <- list(
   write.compression_level = 0L,
   write.chunk_target_mib = 1,
+  quant.clip_warn_pct = 0.5,
+  quant.clip_abort_pct = 5.0,
   quant = list(),
   delta = list()
 )


### PR DESCRIPTION
## Summary
- add `quant.clip_warn_pct` and `quant.clip_abort_pct` default options
- implement clipping abort/warn logic in `forward_step.quant`
- test clipping warning/abort behaviour

## Testing
- `./run-tests.sh` *(fails: R is not installed)*