### PR TITLE
Implement auto_block_size helper

### DIFF
--- a/R/utils_blocksize.R
+++ b/R/utils_blocksize.R
@@ -1,0 +1,39 @@
+#' Automatic Block Size for Spatial Slabs
+#'
+#' Determines spatial slab dimensions for block-wise processing. The
+#' returned slab is chosen so that the estimated memory footprint does
+#' not exceed `target_slab_bytes`. The depth (Z dimension) is reduced
+#' first, then the Y and X dimensions as needed.
+#'
+#' @param spatial_dims Integer vector of length 3 giving the X, Y, Z
+#'   dimensions.
+#' @param element_size_bytes Size in bytes of a single element.
+#' @param target_slab_bytes Target maximum size of a slab in bytes.
+#' @return A list with `slab_dims` (integer vector of length 3) and
+#'   `iterate_slabs` (number of slabs along each dimension).
+#' @keywords internal
+auto_block_size <- function(spatial_dims, element_size_bytes,
+                            target_slab_bytes = 64e6) {
+  stopifnot(is.numeric(spatial_dims), length(spatial_dims) == 3)
+  stopifnot(is.numeric(element_size_bytes), length(element_size_bytes) == 1)
+  dims <- pmax(as.integer(spatial_dims), 1L)
+  size <- as.numeric(element_size_bytes)
+
+  slab <- dims
+  slab[3] <- min(dims[3], 1L)
+
+  bytes <- prod(slab) * size
+  while (bytes > target_slab_bytes && slab[2] > 1) {
+    slab[2] <- ceiling(slab[2] / 2)
+    bytes <- prod(slab) * size
+  }
+  while (bytes > target_slab_bytes && slab[1] > 1) {
+    slab[1] <- ceiling(slab[1] / 2)
+    bytes <- prod(slab) * size
+  }
+
+  slab <- pmax(slab, 1L)
+  iterate <- ceiling(dims / slab)
+  list(slab_dims = slab, iterate_slabs = iterate)
+}
+

--- a/tests/testthat/test-auto_block_size.R
+++ b/tests/testthat/test-auto_block_size.R
@@ -1,0 +1,13 @@
+library(testthat)
+
+# Basic behavior of auto_block_size helper
+
+test_that("auto_block_size reduces slab to target", {
+  res <- auto_block_size(c(64, 64, 32), element_size_bytes = 4,
+                         target_slab_bytes = 64 * 1024)
+  expect_equal(length(res$slab_dims), 3)
+  expect_true(all(res$slab_dims <= c(64, 64, 1)))
+  expect_true(prod(res$slab_dims) * 4 <= 64 * 1024)
+  expect_equal(res$iterate_slabs, ceiling(c(64, 64, 32) / res$slab_dims))
+})
+


### PR DESCRIPTION
## Summary
- add internal helper `auto_block_size()`
- test basic block size calculation

## Testing
- `./run-tests.sh` *(fails: R not installed)*