### PR TITLE
Add set_input implementation for DSL pipeline

### DIFF
--- a/R/pipeline.R
+++ b/R/pipeline.R
@@ -29,6 +29,90 @@ lna_pipeline <- R6::R6Class(
       self$runs <- character()
       self$steps <- list()
       self$engine_opts <- list()
+    },
+
+    #' @description
+    #' Set the pipeline input and related metadata
+    #' @param x Data object or list of run data
+    #' @param run_ids Optional character vector of run identifiers
+    #' @param chunk_mb_suggestion Optional numeric hint for chunk size
+    set_input = function(x, run_ids = NULL, chunk_mb_suggestion = NULL) {
+      if (is.null(x)) {
+        abort_lna(
+          "input `x` must not be NULL",
+          .subclass = "lna_error_validation",
+          location = "lna_pipeline:set_input"
+        )
+      }
+
+      validate_single <- function(obj) {
+        if (!(is.array(obj) || is.matrix(obj) || inherits(obj, "NeuroVec"))) {
+          abort_lna(
+            "input must be array, matrix, NeuroVec or list of such objects",
+            .subclass = "lna_error_validation",
+            location = "lna_pipeline:set_input"
+          )
+        }
+      }
+
+      if (is.list(x) && !inherits(x, "NeuroVec")) {
+        if (length(x) == 0) {
+          abort_lna(
+            "input list must contain at least one element",
+            .subclass = "lna_error_validation",
+            location = "lna_pipeline:set_input"
+          )
+        }
+        lapply(x, validate_single)
+        run_count <- length(x)
+        if (is.null(run_ids)) {
+          if (!is.null(names(x)) && all(names(x) != "")) {
+            self$runs <- names(x)
+          } else {
+            self$runs <- sprintf("run-%02d", seq_len(run_count))
+          }
+        } else {
+          run_ids <- as.character(run_ids)
+          if (length(run_ids) != run_count) {
+            abort_lna(
+              "length of run_ids must match number of list elements",
+              .subclass = "lna_error_validation",
+              location = "lna_pipeline:set_input"
+            )
+          }
+          self$runs <- run_ids
+        }
+        exemplar <- x[[1]]
+      } else {
+        validate_single(x)
+        run_count <- 1L
+        self$runs <- if (is.null(run_ids)) "run-01" else as.character(run_ids[1])
+        exemplar <- x
+      }
+
+      dims <- dim(exemplar)
+      if (is.null(dims)) {
+        time_dim <- length(exemplar)
+        vox_dim <- 1L
+      } else {
+        time_dim <- dims[length(dims)]
+        vox_dim <- if (length(dims) > 1) prod(dims[-length(dims)]) else dims[1]
+      }
+
+      plural <- if (run_count == 1L) "" else "s"
+      self$input_summary <- sprintf(
+        "%d run%s × (%d TR × %s vox)",
+        run_count, plural, as.integer(time_dim), format(as.integer(vox_dim), scientific = FALSE)
+      )
+
+      self$input <- x
+      if (!is.null(chunk_mb_suggestion)) {
+        self$engine_opts$chunk_mb_suggestion <- chunk_mb_suggestion
+      } else {
+        self$engine_opts$chunk_mb_suggestion <- NULL
+      }
+
+      invisible(self)
     }
   )
 )

--- a/tests/testthat/test-lna_pipeline.R
+++ b/tests/testthat/test-lna_pipeline.R
@@ -1,0 +1,33 @@
+library(testthat)
+
+# Tests for lna_pipeline$set_input
+
+test_that("set_input handles single array", {
+  pipe <- neuroarchive:::lna_pipeline$new()
+  arr <- array(1:24, dim = c(2,3,4))
+  pipe$set_input(arr)
+  expect_identical(pipe$input, arr)
+  expect_equal(pipe$runs, "run-01")
+  expect_match(pipe$input_summary, "1 run")
+  expect_match(pipe$input_summary, "4 TR")
+  expect_null(pipe$engine_opts$chunk_mb_suggestion)
+})
+
+test_that("set_input handles named list", {
+  pipe <- neuroarchive:::lna_pipeline$new()
+  arr1 <- array(1:8, dim = c(2,2,2))
+  arr2 <- array(1:8, dim = c(2,2,2))
+  lst <- list(foo = arr1, bar = arr2)
+  pipe$set_input(lst)
+  expect_equal(pipe$runs, c("foo", "bar"))
+  expect_identical(pipe$input, lst)
+})
+
+test_that("set_input handles unnamed list with run_ids", {
+  pipe <- neuroarchive:::lna_pipeline$new()
+  arr1 <- array(1:8, dim = c(2,2,2))
+  arr2 <- array(1:8, dim = c(2,2,2))
+  lst <- list(arr1, arr2)
+  pipe$set_input(lst, run_ids = c("r1", "r2"))
+  expect_equal(pipe$runs, c("r1", "r2"))
+})


### PR DESCRIPTION
## Summary
- implement `lna_pipeline$set_input` to validate and store input, generate run IDs, build input summaries and store engine hints
- add basic unit tests for `set_input`

## Testing
- `./run-tests.sh` *(fails: R is not installed)*