### PR TITLE
Implement QNT-S2-11 docs

### DIFF
--- a/R/dsl_verbs.R
+++ b/R/dsl_verbs.R
@@ -100,10 +100,25 @@ lna_write <- function(pipeline_obj, file, ...,
 #' global `lna_options("quant")`, and user-supplied arguments.
 #'
 #' @param data_or_pipe Data object or `lna_pipeline`.
-#' @param bits Optional number of quantization bits.
+#' @param bits Number of quantization bits (1-16). If `NULL`, the
+#'   schema default is used.
+#' @param method Method for determining scale/offset (`"range"` or
+#'   `"sd"`).
+#' @param center Logical indicating whether the data should be
+#'   effectively centered before quantisation.
+#' @param scale_scope Either `"global"` for one scale/offset or
+#'   `"voxel"` for per-voxel parameters.
+#' @param allow_clip If `TRUE`, quantisation proceeds even when the
+#'   clipping percentage exceeds `lna.quant.clip_abort_pct`.
 #' @param ... Additional parameters for the quant transform.
 #'
 #' @return An `lna_pipeline` object with the quant step appended.
+#'
+#' @examples
+#' # allow over 5% clipping without error
+#' pipe <- as_pipeline(matrix(rnorm(10), 5, 2))
+#' pipe <- quant(pipe, bits = 4, allow_clip = TRUE)
+#'
 #' @export
 quant <- function(data_or_pipe, bits = NULL, ...) {
   pipe <- if (inherits(data_or_pipe, "lna_pipeline")) {

--- a/R/transform_quant.R
+++ b/R/transform_quant.R
@@ -1,6 +1,12 @@
 #' Quantization Transform - Forward Step
 #'
-#' Applies simple min-max quantization to numeric data.
+#' Implements the writer-side quant step. Parameters follow the quant
+#' schema (`bits`, `method`, `center`, `scale_scope`, `allow_clip`).
+#' Excessive clipping triggers an error unless `allow_clip` is `TRUE`.
+#'
+#' @param type,desc,handle Internal arguments used by the transform
+#'   dispatcher.
+#' @return None. Updates the write plan and `handle$meta`.
 #' @keywords internal
 forward_step.quant <- function(type, desc, handle) {
   p <- desc$params %||% list()
@@ -290,7 +296,13 @@ forward_step.quant <- function(type, desc, handle) {
 
 #' Quantization Transform - Inverse Step
 #'
-#' Reconstructs data from quantized representation stored in HDF5.
+#' Reads quantized values and reconstructs the original data using the
+#' stored scale and offset. Validates the `quant_bits` attribute and
+#' handles legacy files missing it.
+#'
+#' @param type,desc,handle Internal arguments used by the transform
+#'   dispatcher.
+#' @return None. Places the reconstructed array into `handle$stash`.
 #' @keywords internal
 invert_step.quant <- function(type, desc, handle) {
   run_id <- handle$current_run_id %||% "run-01"

--- a/man/forward_step.quant.Rd
+++ b/man/forward_step.quant.Rd
@@ -7,6 +7,8 @@
 \method{forward_step}{quant}(type, desc, handle)
 }
 \description{
-Applies simple min-max quantization to numeric data.
+Implements the writer-side quantisation step. Parameters follow the
+quant schema and clipping beyond thresholds aborts unless
+\code{allow_clip} is \code{TRUE}.
 }
 \keyword{internal}

--- a/man/invert_step.quant.Rd
+++ b/man/invert_step.quant.Rd
@@ -7,6 +7,7 @@
 \method{invert_step}{quant}(type, desc, handle)
 }
 \description{
-Reconstructs data from quantized representation stored in HDF5.
+Reads quantised values, validates the \code{quant_bits} attribute and
+reconstructs the original data using stored scale and offset.
 }
 \keyword{internal}

--- a/man/quant.Rd
+++ b/man/quant.Rd
@@ -1,0 +1,25 @@
+% Manual page for the quant DSL verb
+% Please edit documentation in R/dsl_verbs.R
+\name{quant}
+\alias{quant}
+\title{Add a quantisation step to a pipeline}
+\usage{
+quant(data_or_pipe, bits = NULL, method = "range", center = TRUE,
+      scale_scope = "global", allow_clip = FALSE, ...)
+}
+\arguments{
+  \item{data_or_pipe}{Data object or \code{lna_pipeline}.}
+  \item{bits}{Number of quantisation bits (1-16). If \code{NULL}, the schema default is used.}
+  \item{method}{Method for deriving scale/offset: \code{"range"} or \code{"sd"}.}
+  \item{center}{Logical indicating whether the data should be centred before quantisation.}
+  \item{scale_scope}{Either \code{"global"} for one scale/offset or \code{"voxel"} for per-voxel parameters.}
+  \item{allow_clip}{If \code{TRUE}, quantisation proceeds even when clipping exceeds \code{lna.quant.clip_abort_pct}.}
+  \item{...}{Additional parameters forwarded to the transform.}
+}
+\value{An \code{lna_pipeline} object with the quant step appended.}
+\examples
+{\donttest{
+pipe <- as_pipeline(matrix(rnorm(10), 5, 2))
+pipe <- quant(pipe, bits = 4, allow_clip = TRUE)
+}}
+\keyword{manip}

--- a/vignettes/quant_bits_and_report.Rmd
+++ b/vignettes/quant_bits_and_report.Rmd
@@ -1,0 +1,48 @@
+---
+title: "Choosing Bits and Interpreting the Quantization Report"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Choosing Bits and Interpreting the Quantization Report}
+  %\VignetteEngine{rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+This vignette demonstrates how to pick an appropriate number of
+quantisation bits and how to inspect the diagnostics produced by the
+`quant` transform.
+
+```r
+library(neuroarchive)
+```
+
+## Writing data with quantisation
+
+```r
+set.seed(1)
+x <- array(rnorm(200), dim = c(10, 10, 2))
+file <- tempfile(fileext = ".h5")
+write_lna(x, file, transforms = "quant",
+          transform_params = list(quant = list(bits = 6,
+                                               allow_clip = TRUE)))
+```
+
+## Reading the quantisation report
+
+```r
+rep <- lna_get_quant_report(file, 0)
+print(rep)
+```
+
+A simple histogram of the quantised values can be created from the
+`histogram_quantized_values` entry of the report:
+
+```r
+hist(rep$histogram_quantized_values$breaks[-1],
+     rep$histogram_quantized_values$counts,
+     main = "Quantised value distribution",
+     xlab = "Quant level", ylab = "Count",
+     type = "h")
+```
+
+The report also contains the estimated signal-to-noise ratio (SNR) in dB
+which can help decide whether more bits are required.


### PR DESCRIPTION
## Summary
- expand documentation for `forward_step.quant` and `invert_step.quant`
- document all parameters for the `quant()` DSL verb
- add vignette explaining how to choose quantisation bits and read the quant report

## Testing
- `./run-tests.sh` *(fails: R is not installed)*