### PR TITLE
Implement embed step inference

### DIFF
--- a/inst/schemas/embed.hrbf_analytic.schema.json
+++ b/inst/schemas/embed.hrbf_analytic.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Descriptor for 'embed.hrbf_analytic' transform",
+  "type": "object",
+  "properties": {
+    "type": { "const": "embed.hrbf_analytic" },
+    "basis_path": {"type": "string", "default": ""},
+    "center_data_with": {"type": ["string", "null"], "default": null},
+    "scale_data_with": {"type": ["string", "null"], "default": null}
+  },
+  "required": ["type", "basis_path"],
+  "additionalProperties": false
+}

--- a/inst/schemas/embed.pca.schema.json
+++ b/inst/schemas/embed.pca.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Descriptor for 'embed.pca' transform",
+  "type": "object",
+  "properties": {
+    "type": { "const": "embed.pca" },
+    "basis_path": {"type": "string", "default": ""},
+    "center_data_with": {"type": ["string", "null"], "default": null},
+    "scale_data_with": {"type": ["string", "null"], "default": null}
+  },
+  "required": ["type", "basis_path"],
+  "additionalProperties": false
+}

--- a/tests/testthat/test-dsl_verbs.R
+++ b/tests/testthat/test-dsl_verbs.R
@@ -79,10 +79,10 @@ test_that("pca -> embed -> quant pipeline executes", {
   pipe <- quant(pipe, bits = 6)
   lna_write(pipe, file = "bar.h5")
 
-  expect_equal(captured$transforms, c("basis", "embed", "quant"))
+  expect_equal(captured$transforms, c("basis", "embed.pca", "quant"))
   expect_equal(captured$transform_params$basis$k, 2)
   expect_equal(captured$transform_params$quant$bits, 6)
-  expect_equal(captured$transform_params$embed$basis_path, "/basis/00_basis/matrix")
+  expect_equal(captured$transform_params$`embed.pca`$basis_path, "/basis/00_basis/matrix")
 })
 
 test_that("embed() without prior basis step errors", {

--- a/tests/testthat/test-dsl_verbs_extended.R
+++ b/tests/testthat/test-dsl_verbs_extended.R
@@ -68,7 +68,7 @@ test_that("embed() infers path after hrbf", {
   pipe <- hrbf(arr)
   pipe <- embed(pipe)
   step <- pipe$steps[[2]]
-  expect_equal(step$type, "embed")
+  expect_equal(step$type, "embed.hrbf_analytic")
   expect_true(grepl("/basis/00_spat.hrbf/matrix", step$params$basis_path))
 })
 


### PR DESCRIPTION
## Summary
- add `infer_embed_step()` helper to inspect previous pipeline step
- update `embed()` verb to use helper and adjust default params
- provide schemas for `embed.pca` and `embed.hrbf_analytic`
- adjust tests for new embed step types

## Testing
- `./run-tests.sh` *(fails: R is not installed)*