### PR TITLE
Implement NI2LNA-S1-5 doc updates

### DIFF
--- a/R/api.R
+++ b/R/api.R
@@ -7,10 +7,10 @@
 #' options set via `lna_options()`, and any user supplied
 #' `transform_params` (later values override earlier ones).
 #'
-#' @param x Numeric array or list of arrays. Each array must have at
-#'   least three dimensions (`x`, `y`, `z`, and optionally `time`). If a
-#'   list is supplied each element represents a run. When `x` is a single
-#'   array it is treated as one run.
+#' @param x Numeric array or `DenseNeuroVec` (or list of those). Each
+#'   array must have at least three dimensions (`x`, `y`, `z`, and
+#'   optionally `time`). 3D inputs (`DenseNeuroVol` or 3D array) are
+#'   expanded to 4D. Lists denote multiple runs.
 #' @param file Path to the output `.h5` file. If `NULL`, writing occurs
 #'   in memory using the HDF5 core driver and no file is created. The
 #'   returned result then contains `file = NULL`.
@@ -21,7 +21,8 @@
 #' @param mask Optional: a `LogicalNeuroVol` or 3D logical array used to
 #'   subset voxels prior to compression.
 #' @param header Optional named list of header attributes to store under
-#'   `/header`.
+#'   `/header`. When `NULL` and `x` inherits from `NeuroObj` the header is
+#'   created from its `NeuroSpace`.
 #' @param plugins Optional named list saved under the `/plugins` group.
 #' @param block_table Optional data frame specifying spatial block
 #'   coordinates stored at `/spatial/block_table`. Columns must contain

--- a/man/write_lna.Rd
+++ b/man/write_lna.Rd
@@ -8,9 +8,10 @@ write_lna(x, file = NULL, transforms = character(),
           checksum = c("none", "sha256"))
 }
 \arguments{
-  \item{x}{Numeric array or list of arrays. Each array should have at least
-  three dimensions (\code{x}, \code{y}, \code{z}, optionally \code{time}). Lists
-  denote multiple runs.}
+  \item{x}{Numeric array or \code{DenseNeuroVec} object, or a list of those.
+  Each array must have at least three dimensions (\code{x}, \code{y}, \code{z},
+  optionally \code{time}). 3D inputs (arrays or \code{DenseNeuroVol}) are
+  automatically expanded to 4D. Lists denote multiple runs.}
   \item{file}{Path to output \code{.h5} file. If \code{NULL}, writing is
   performed in memory using the HDF5 core driver and no file is created. The
   returned result then contains \code{file = NULL}.}
@@ -20,7 +21,8 @@ write_lna(x, file = NULL, transforms = character(),
   \item{mask}{Optional \code{LogicalNeuroVol} or 3D logical array used to subset
   voxels prior to compression.}
   \item{header}{Optional named list of header attributes stored under
-  \code{/header}.}
+  \code{/header}. When \code{NULL} and \code{x} is a \code{NeuroObj},
+  a header is created from its \code{NeuroSpace}.}
   \item{plugins}{Optional named list saved to the \code{/plugins} group.}
   \item{block_table}{Optional data frame of spatial block coordinates stored
   under \code{/spatial/block_table}. Columns must contain 1-based voxel indices
@@ -38,9 +40,17 @@ Parameter values are merged from the transform schemas, package options and the
 user supplied \code{transform_params}. The optional \code{mask}, \code{header},
 \code{plugins} and \code{block_table} are written to the corresponding HDF5
 groups. Use \code{read_lna()} to reconstruct the data.}
+If \code{header} is \code{NULL} and \code{x} is a \code{NeuroObj}, the header is
+auto-populated using \code{neuroim2_space_to_lna_header(space(x))}.
 \seealso{\code{\link{read_lna}}, \code{\link{validate_lna}}}
 \examples{
 x <- array(rnorm(64), dim = c(4,4,4,1))
 write_lna(x, "ex.h5", transforms = "quant")
 read_lna("ex.h5")
+
+# Example with a DenseNeuroVec from neuroim2
+# library(neuroim2)
+# vec <- neuroim2::DenseNeuroVec(array(rnorm(64), dim = c(4,4,4,1)),
+#                                space = neuroim2::NeuroSpace(c(4,4,4,1)))
+# write_lna(vec, "vec_ex.h5")
 }

--- a/vignettes/neuroim2_roundtrip.Rmd
+++ b/vignettes/neuroim2_roundtrip.Rmd
@@ -1,0 +1,29 @@
+---
+title: "Round-Trip with neuroim2"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Round-Trip with neuroim2}
+  %\VignetteEngine{rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+This vignette shows a minimal example of writing a `neuroim2` object to
+an LNA file and reading it back.
+
+```r
+library(neuroarchive)
+# library(neuroim2) # for real use
+
+# Read a NIfTI using neuroim2 (example path)
+# vec <- neuroim2::read_vec("func.nii.gz")
+# Ensure we have a DenseNeuroVec
+# vec <- as(vec, "DenseNeuroVec")
+
+# Write to LNA
+# write_lna(vec, "roundtrip.h5", transforms = "quant")
+
+# Read back
+# read_lna("roundtrip.h5")
+
+# Future: read_lna("roundtrip.h5", as_neuroim = TRUE)
+```


### PR DESCRIPTION
## Summary
- document neuroim2 object support in `write_lna`
- mention automatic header creation when passed a NeuroObj
- add example snippet showing DenseNeuroVec usage
- add vignette demonstrating a neuroim2 round trip

## Testing
- `./run-tests.sh` *(fails: R is not installed)*