### PR TITLE
Improve delta transform performance with col_cumsums helper

### DIFF
--- a/R/transform_delta.R
+++ b/R/transform_delta.R
@@ -254,7 +254,7 @@ invert_step.delta <- function(type, desc, handle) {
     deltas <- matrix(delta_stream, nrow = expected_nrows_deltas, ncol = expected_ncols)
   }
 
-  cums <- matrix(apply(deltas, 2, cumsum), nrow = expected_nrows_deltas, ncol = expected_ncols)
+  cums <- .col_cumsums(deltas)
   recon <- rbind(first_vals, sweep(cums, 2, first_vals, "+"))
 
   perm <- c(axis, setdiff(seq_along(dims), axis))

--- a/R/utils_matrix.R
+++ b/R/utils_matrix.R
@@ -1,0 +1,22 @@
+#' Column-wise cumulative sums
+#'
+#' Computes column-wise cumulative sums of a numeric matrix. If the
+#' `matrixStats` package is installed, `matrixStats::colCumsums` is used
+#' for efficiency. Otherwise a simple column loop is performed.
+#'
+#' @param x Numeric matrix.
+#' @return Matrix of the same dimensions as `x` containing cumulative sums
+#'   down each column.
+#' @keywords internal
+.col_cumsums <- function(x) {
+  stopifnot(is.matrix(x))
+  if (requireNamespace("matrixStats", quietly = TRUE)) {
+    matrixStats::colCumsums(x)
+  } else {
+    res <- matrix(0, nrow = nrow(x), ncol = ncol(x))
+    for (j in seq_len(ncol(x))) {
+      res[, j] <- cumsum(x[, j])
+    }
+    res
+  }
+}


### PR DESCRIPTION
## Summary
- add `.col_cumsums` helper using `matrixStats::colCumsums` when available
- use `.col_cumsums` in delta transform inverse step

## Testing
- `bash run-tests.sh` *(fails: R is not installed)*