### PR TITLE
Move path_exists_safely helper

### DIFF
--- a/R/transform_embed.R
+++ b/R/transform_embed.R
@@ -99,18 +99,6 @@ invert_step.embed <- function(type, desc, handle) {
 
   root <- handle$h5[["/"]]
 
-  path_exists_safely <- function(group, path_name) {
-    if (is.null(path_name) || !nzchar(path_name)) return(FALSE)
-    tryCatch({
-      group$exists(path_name)
-    }, error = function(e) {
-      # If the error is specifically about the path not existing, treat as FALSE
-      # Otherwise, could re-throw if it's a more fundamental HDF5 issue.
-      # For now, any error in exists() implies we can't use the path.
-      FALSE
-    })
-  }
-
   if (!path_exists_safely(root, basis_path)) {
     abort_lna(sprintf("dataset '%s' not found", basis_path),
               .subclass = "lna_error_contract",

--- a/R/utils_hdf5.R
+++ b/R/utils_hdf5.R
@@ -383,6 +383,25 @@ close_h5_safely <- function(h5) {
   invisible(NULL)
 }
 
+#' Safely check for the existence of an HDF5 path
+#'
+#' Wrapper around `H5Group$exists` that treats any error as the path not
+#' existing. This is useful when paths may contain characters that `exists()`
+#' cannot handle cleanly.
+#'
+#' @param group An `H5File` or `H5Group` to check.
+#' @param path_name Character path to test.
+#' @return Logical `TRUE` if the path exists, otherwise `FALSE`.
+#' @keywords internal
+path_exists_safely <- function(group, path_name) {
+  if (is.null(path_name) || !nzchar(path_name)) return(FALSE)
+  tryCatch({
+    group$exists(path_name)
+  }, error = function(e) {
+    FALSE
+  })
+}
+
 #' Assert that an HDF5 path exists
 #'
 #' Convenience helper to verify that a dataset or group is present


### PR DESCRIPTION
## Summary
- extract the `path_exists_safely` helper to `utils_hdf5.R`
- use the new helper in `invert_step.embed`

## Testing
- `bash run-tests.sh` *(fails: R is not installed)*