### PR TITLE
Validate pipeline input dimensions

### DIFF
--- a/R/pipeline.R
+++ b/R/pipeline.R
@@ -64,6 +64,16 @@ lna_pipeline <- R6::R6Class(
           )
         }
         lapply(x, validate_single)
+
+        ref_dim <- dim(x[[1]])
+        if (!all(vapply(x, function(el) identical(dim(el), ref_dim), logical(1)))) {
+          abort_lna(
+            "all input elements must have identical dimensions",
+            .subclass = "lna_error_validation",
+            location = "lna_pipeline:set_input"
+          )
+        }
+
         run_count <- length(x)
         if (is.null(run_ids)) {
           if (!is.null(names(x)) && all(names(x) != "")) {

--- a/tests/testthat/test-lna_pipeline.R
+++ b/tests/testthat/test-lna_pipeline.R
@@ -32,6 +32,17 @@ test_that("set_input handles unnamed list with run_ids", {
   expect_equal(pipe$runs, c("r1", "r2"))
 })
 
+test_that("set_input requires identical element dimensions", {
+  pipe <- neuroarchive:::lna_pipeline$new()
+  arr1 <- array(1:8, dim = c(2,2,2))
+  arr2 <- array(1:9, dim = c(3,3,1))
+  expect_error(
+    pipe$set_input(list(arr1, arr2)),
+    "all input elements must have identical dimensions",
+    class = "lna_error_validation"
+  )
+})
+
 # Test lna_pipeline$new defaults
 
 test_that("lna_pipeline fields initialise correctly", {


### PR DESCRIPTION
## Summary
- ensure `lna_pipeline$set_input()` verifies identical dimensions across list elements
- add regression test

## Testing
- `./run-tests.sh` *(fails: R is not installed)*