### PR TITLE
Implement HRBF-S1-5 basis matrix step

### DIFF
--- a/R/transform_spat_hrbf.R
+++ b/R/transform_spat_hrbf.R
@@ -67,20 +67,56 @@ forward_step.spat.hrbf <- function(type, desc, handle) {
   mask_hash_val <- digest::digest(as.array(mask_neurovol), algo = "sha256", serialize = FALSE)
   p$mask_hash <- paste0("sha256:", mask_hash_val)
 
+  # -- Basis Matrix Construction (HRBF-S1-5) ---------------------------------
+  mask_arr <- as.array(mask_neurovol)
+  mask_idx <- which(mask_arr)
+  vox_coords <- which(mask_arr, arr.ind = TRUE)
+  mask_coords_world <- voxel_to_world(vox_coords)
+
+  k <- nrow(C_total)
+  n_vox <- length(mask_idx)
+  B_final <- matrix(0, nrow = k, ncol = n_vox)
+
+  if (k > 0) {
+    for (i in seq_len(k)) {
+      atom <- generate_hrbf_atom(mask_coords_world, mask_idx,
+                                 C_total[i, ], sigma_vec[i],
+                                 kernel_type = kernel_type,
+                                 normalize_over_mask = TRUE)
+      B_final[i, ] <- atom$values
+    }
+  }
+
   desc$params <- p
   desc$version <- "1.0"
   desc$inputs <- desc$inputs %||% character()
   desc$outputs <- character()
-  desc$datasets <- list()
+  datasets <- list()
 
   plan <- handle$plan
+  step_index <- plan$next_index
   fname <- plan$get_next_filename(type)
+  base_name <- tools::file_path_sans_ext(fname)
+
+  if (isTRUE(p$store_dense_matrix)) {
+    matrix_path <- paste0("/basis/", base_name, "/matrix")
+    datasets[[1]] <- list(path = matrix_path, role = "basis_matrix")
+    params_json <- as.character(jsonlite::toJSON(p, auto_unbox = TRUE))
+    plan$add_payload(matrix_path, B_final)
+    plan$add_dataset_def(matrix_path, "basis_matrix", type,
+                         plan$origin_label, as.integer(step_index),
+                         params_json, matrix_path, "eager", dtype = NA_character_)
+  }
+
+  desc$datasets <- datasets
+
   plan$add_descriptor(fname, desc)
   handle$plan <- plan
 
   handle$update_stash(keys = character(),
                       new_values = list(hrbf_centres = C_total,
-                                         hrbf_sigmas = sigma_vec))
+                                         hrbf_sigmas = sigma_vec,
+                                         hrbf_basis = B_final))
 }
 
 #' Default parameters for the 'spat.hrbf' transform


### PR DESCRIPTION
## Summary
- construct HRBF basis matrix in `forward_step.spat.hrbf`
- optionally store matrix payload when `store_dense_matrix` is requested

## Testing
- `bash run-tests.sh` *(fails: R is not installed)*