### PR TITLE
Wrap temporal debug messages behind option

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,3 +10,5 @@
 * A detailed quantization report is produced in JSON format and
   written to the file (compressed with GZIP). Retrieve it with
   `lna_get_quant_report()`.
+* Added `lna.debug.temporal` option. When `TRUE`, `forward_step.temporal` and
+  `invert_step.temporal` emit debug messages; defaults to `FALSE` for quiet runs.

--- a/man/forward_step.temporal.Rd
+++ b/man/forward_step.temporal.Rd
@@ -8,5 +8,6 @@
 }
 \description{
 Projects data onto a temporal basis (DCT, B-spline, DPSS, polynomial, or wavelet).
+Debug output is controlled by the \code{lna.debug.temporal} option.
 }
 \keyword{internal}

--- a/man/invert_step.temporal.Rd
+++ b/man/invert_step.temporal.Rd
@@ -8,5 +8,6 @@
 }
 \description{
 Reconstructs data from stored temporal basis coefficients.
+Debug output is controlled by the \code{lna.debug.temporal} option.
 }
 \keyword{internal}


### PR DESCRIPTION
## Summary
- quiet default runs by gating verbose messages in `forward_step.temporal` and `invert_step.temporal` behind `lna.debug.temporal`
- update documentation for the new option

## Testing
- `./run-tests.sh` *(fails: R is not installed)*