### PR TITLE
Fix input selection for temporal transform

### DIFF
--- a/R/transform_temporal.R
+++ b/R/transform_temporal.R
@@ -12,8 +12,11 @@ forward_step.temporal <- function(type, desc, handle) {
   p$n_basis <- NULL
   order <- p$order %||% 3
   p$order <- NULL
-  # Determine input key based on previous transform's output
-  if (handle$has_key("temporal_coefficients") && FALSE) { # avoid self-loop
+  # Determine input key based on previous transform's output.
+  # When temporal coefficients are already present we treat them as
+  # the input so additional temporal steps operate on the projected
+  # coefficients rather than reusing the raw matrix.
+  if (handle$has_key("temporal_coefficients")) {
     input_key <- "temporal_coefficients"
   } else if (handle$has_key("delta_stream")) {
     input_key <- "delta_stream"

--- a/repomix-output.xml
+++ b/repomix-output.xml
@@ -4890,8 +4890,11 @@ forward_step.temporal <- function(type, desc, handle) {
   p$n_basis <- NULL
   order <- p$order %||% 3
   p$order <- NULL
-  # Determine input key based on previous transform's output
-  if (handle$has_key("temporal_coefficients") && FALSE) { # avoid self-loop
+  # Determine input key based on previous transform's output.
+  # When temporal coefficients are already present we treat them as
+  # the input so additional temporal steps operate on the projected
+  # coefficients rather than reusing the raw matrix.
+  if (handle$has_key("temporal_coefficients")) {
     input_key <- "temporal_coefficients"
   } else if (handle$has_key("delta_stream")) {
     input_key <- "delta_stream"


### PR DESCRIPTION
## Summary
- simplify `forward_step.temporal` logic by removing always-false check
- document how temporal coefficients are reused when they already exist

## Testing
- `./run-tests.sh` *(fails: R is not installed)*