### PR TITLE
Improve temporal basis efficiency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,6 +28,7 @@ Imports:
 Suggests:
     sparsepca,
     irlba,
-    testthat (>= 3.0.0)
+    testthat (>= 3.0.0),
+    multitaper
 Config/testthat/edition: 3
 RoxygenNote: 7.3.2.9000

--- a/man/dot-dpss_basis.Rd
+++ b/man/dot-dpss_basis.Rd
@@ -7,6 +7,6 @@
 .dpss_basis(n_time, n_basis, NW)
 }
 \description{
-Generate DPSS basis matrix
+Generate DPSS basis matrix using \code{multitaper::dpss.taper} when available
 }
 \keyword{internal}

--- a/man/dot-wavelet_basis.Rd
+++ b/man/dot-wavelet_basis.Rd
@@ -9,6 +9,8 @@
 \description{
 Daubechies 4 ("db4") tends to balance temporal resolution and smoothness
 for fMRI applications, so it is used as the default.
-Any wavelet supported by the `wavelets` package may be supplied.
+Any wavelet supported by the `wavelets` package may be supplied. The
+computation is vectorised with \code{vapply} to avoid creating an explicit
+identity matrix.
 }
 \keyword{internal}


### PR DESCRIPTION
## Summary
- use `multitaper::dpss.taper()` when available for DPSS basis
- vectorise wavelet basis computation
- document the new approaches
- suggest the `multitaper` package for optional use

## Testing
- `./run-tests.sh` *(fails: R is not installed)*