### PR TITLE
Conditionally display handle debug messages

### DIFF
--- a/R/handle.R
+++ b/R/handle.R
@@ -93,8 +93,12 @@ DataHandle <- R6::R6Class("DataHandle",
     #' @param new_values Named list of new objects to add to the stash.
     #' @return A *new* DataHandle object with the updated stash.
     update_stash = function(keys, new_values) {
-      message(sprintf("[DataHandle$update_stash ENTRY] Self stash keys: %s. ", paste(names(self$stash), collapse=", ")))
-      message(sprintf("[DataHandle$update_stash ENTRY] new_values keys: %s. ", paste(names(new_values), collapse=", ")))
+      if (isTRUE(getOption("neuroarchive.debug", FALSE))) {
+        message(sprintf("[DataHandle$update_stash ENTRY] Self stash keys: %s. ",
+                        paste(names(self$stash), collapse=", ")))
+        message(sprintf("[DataHandle$update_stash ENTRY] new_values keys: %s. ",
+                        paste(names(new_values), collapse=", ")))
+      }
   
       stopifnot(is.character(keys))
       stopifnot(is.list(new_values))
@@ -144,7 +148,11 @@ DataHandle <- R6::R6Class("DataHandle",
         # TODO: Add validation specific to field types? (e.g., plan must be Plan)
         new_obj[[field_name]] <- updates[[field_name]]
       }
-      message(sprintf("[DataHandle$with] Returning new_obj. Stash keys: %s. Is input in stash NULL? %s", paste(names(new_obj$stash), collapse=", "), is.null(new_obj$stash$input)))
+      if (isTRUE(getOption("neuroarchive.debug", FALSE))) {
+        message(sprintf("[DataHandle$with] Returning new_obj. Stash keys: %s. Is input in stash NULL? %s",
+                        paste(names(new_obj$stash), collapse=", "),
+                        is.null(new_obj$stash$input)))
+      }
       return(new_obj)
     },
 


### PR DESCRIPTION
## Summary
- gate debug `message()` calls in `DataHandle` behind `getOption("neuroarchive.debug", FALSE)`

## Testing
- `./run-tests.sh` *(fails: R is not installed)*