### PR TITLE
Implement extra fine-scale HRBF levels

### DIFF
--- a/R/transform_basis_empirical_hrbf_compressed.R
+++ b/R/transform_basis_empirical_hrbf_compressed.R
@@ -171,6 +171,7 @@ forward_step.basis.empirical_hrbf_compressed <- function(type, desc, handle) {
   sigma0 <- p$sigma0 %||% 6
   levels <- p$levels %||% 3L
   radius_factor <- p$radius_factor %||% 2.5
+  num_extra_fine_levels <- p$num_extra_fine_levels %||% 0L
   kernel_type <- p$kernel_type %||% "gaussian"
   seed <- p$seed %||% 1L
 
@@ -190,6 +191,19 @@ forward_step.basis.empirical_hrbf_compressed <- function(type, desc, handle) {
     if (nrow(vox_centres) > 0) {
       centres_list[[length(centres_list) + 1L]] <- voxel_to_world(vox_centres)
       sigs <- c(sigs, rep(sigma_j, nrow(vox_centres)))
+    }
+  }
+  if (num_extra_fine_levels > 0L) {
+    for (j_extra in seq_len(num_extra_fine_levels)) {
+      sigma_new <- sigma0 / (2^(levels + j_extra))
+      r_new <- radius_factor * sigma_new
+      vox_centres <- poisson_disk_sample_neuroim2(
+        mask_neurovol, r_new, seed + levels + j_extra
+      )
+      if (nrow(vox_centres) > 0) {
+        centres_list[[length(centres_list) + 1L]] <- voxel_to_world(vox_centres)
+        sigs <- c(sigs, rep(sigma_new, nrow(vox_centres)))
+      }
     }
   }
   C_total <- if (length(centres_list) > 0) do.call(rbind, centres_list)

--- a/tests/testthat/test-transform_spat_hrbf.R
+++ b/tests/testthat/test-transform_spat_hrbf.R
@@ -84,3 +84,31 @@ test_that("forward_step.spat.hrbf computes coefficients", {
   C <- h2$stash$coefficients_hrbf
   expect_equal(nrow(C), nrow(X))
 })
+
+test_that("num_extra_fine_levels increases k_actual", {
+  mask <- array(TRUE, dim = c(3,3,3))
+  vol <- structure(list(arr = mask), class = "LogicalNeuroVol")
+  attr(vol, "space") <- FakeSpace(c(3,3,3), c(1,1,1))
+
+  plan1 <- Plan$new()
+  h1 <- DataHandle$new(initial_stash = list(input = matrix(0, nrow = 1, ncol = 27)),
+                       plan = plan1, mask_info = list(mask = vol, active_voxels = 27))
+  desc1 <- list(type = "spat.hrbf",
+                params = list(sigma0 = 6, levels = 0, radius_factor = 2.5,
+                               kernel_type = "gaussian", seed = 1,
+                               num_extra_fine_levels = 0))
+  out1 <- neuroarchive:::forward_step.spat.hrbf("spat.hrbf", desc1, h1)
+  k1 <- out1$plan$descriptors[[1]]$params$k_actual
+
+  plan2 <- Plan$new()
+  h2 <- DataHandle$new(initial_stash = list(input = matrix(0, nrow = 1, ncol = 27)),
+                       plan = plan2, mask_info = list(mask = vol, active_voxels = 27))
+  desc2 <- list(type = "spat.hrbf",
+                params = list(sigma0 = 6, levels = 0, radius_factor = 2.5,
+                               kernel_type = "gaussian", seed = 1,
+                               num_extra_fine_levels = 1))
+  out2 <- neuroarchive:::forward_step.spat.hrbf("spat.hrbf", desc2, h2)
+  k2 <- out2$plan$descriptors[[1]]$params$k_actual
+
+  expect_gt(k2, k1)
+})


### PR DESCRIPTION
## Summary
- add `num_extra_fine_levels` handling in `forward_step.spat.hrbf`
- regenerate centres with additional fine levels in invert and helper functions
- support extra fine levels in empirical HRBF basis helper
- test that extra fine levels increase number of centres

## Testing
- `./run-tests.sh` *(fails: R is not installed)*