### PR TITLE
Implement HRBF cached world coords

### DIFF
--- a/R/hrbf_core.R
+++ b/R/hrbf_core.R
@@ -12,8 +12,14 @@
 #'   returns the coefficient matrix and `hrbf_reconstruct_matrix` returns
 #'   a dense numeric matrix.
 #' @export
-hrbf_generate_basis <- function(params, mask, h5_root = NULL) {
-  hrbf_basis_from_params(params, mask, h5_root)
+hrbf_generate_basis <- function(params, mask, h5_root = NULL,
+                                mask_world_coords = NULL,
+                                mask_arr = NULL,
+                                mask_linear_indices = NULL) {
+  hrbf_basis_from_params(params, mask, h5_root,
+                         mask_world_coords = mask_world_coords,
+                         mask_arr = mask_arr,
+                         mask_linear_indices = mask_linear_indices)
 }
 
 #' @rdname hrbf_generate_basis

--- a/R/hrbf_helpers.R
+++ b/R/hrbf_helpers.R
@@ -252,7 +252,9 @@ generate_hrbf_atom <- function(mask_coords_world, mask_linear_indices,
 #' @return Sparse matrix with one row per HRBF atom and columns matching
 #'   mask voxels.
 #' @keywords internal
-hrbf_basis_from_params <- function(params, mask_neurovol, h5_root = NULL) {
+hrbf_basis_from_params <- function(params, mask_neurovol, h5_root = NULL,
+                                   mask_world_coords = NULL, mask_arr = NULL,
+                                   mask_linear_indices = NULL) {
   sigma0 <- params$sigma0 %||% 6
   levels <- params$levels %||% 3L
   radius_factor <- params$radius_factor %||% 2.5
@@ -314,10 +316,16 @@ hrbf_basis_from_params <- function(params, mask_neurovol, h5_root = NULL) {
               location = "hrbf_basis_from_params")
   }
 
-  mask_arr <- as.array(mask_neurovol)
-  mask_coords_vox <- which(mask_arr, arr.ind = TRUE)
-  mask_coords_world <- voxel_to_world(mask_coords_vox)
-  mask_linear_indices <- as.integer(which(mask_arr))
+  if (is.null(mask_arr)) {
+    mask_arr <- as.array(mask_neurovol)
+  }
+  if (is.null(mask_world_coords)) {
+    mask_coords_vox <- which(mask_arr, arr.ind = TRUE)
+    mask_world_coords <- voxel_to_world(mask_coords_vox)
+  }
+  if (is.null(mask_linear_indices)) {
+    mask_linear_indices <- as.integer(which(mask_arr))
+  }
   n_total_vox <- length(mask_arr)
   k_actual <- nrow(C_total)
 

--- a/R/transform_spat_hrbf.R
+++ b/R/transform_spat_hrbf.R
@@ -23,6 +23,12 @@ forward_step.spat.hrbf <- function(type, desc, handle) {
               location = "forward_step.spat.hrbf:mask")
   }
 
+  mask_arr <- as.array(mask_neurovol)
+  cached_mask_world_coords <- neuroim2::grid_to_coord(
+    mask_neurovol, which(mask_arr, arr.ind = TRUE)
+  )
+  mask_linear_indices <- as.integer(which(mask_arr))
+
   ## Advanced parameter validation / stubs ----
   if (isTRUE(p$use_anisotropic_atoms)) {
     if (is.null(p$anisotropy_source_path)) {
@@ -149,8 +155,13 @@ forward_step.spat.hrbf <- function(type, desc, handle) {
 
 
 
-  B_final <- hrbf_generate_basis(p, mask_neurovol,
-                                 if (!is.null(handle$h5)) handle$h5[["/"]] else NULL)
+  B_final <- hrbf_generate_basis(
+    p, mask_neurovol,
+    if (!is.null(handle$h5)) handle$h5[["/"]] else NULL,
+    mask_world_coords = cached_mask_world_coords,
+    mask_arr = mask_arr,
+    mask_linear_indices = mask_linear_indices
+  )
 
   matrix_path <- "/basis/hrbf/analytic/matrix"
   params_json <- as.character(jsonlite::toJSON(p, auto_unbox = TRUE))


### PR DESCRIPTION
## Summary
- generate HRBF basis with cached world coords
- expose optional parameters in hrbf helpers
- use cached coordinates in `forward_step.spat.hrbf`

## Testing
- `./run-tests.sh` *(fails: R is not installed)*