### PR TITLE
Document extra HRBF fine levels

### DIFF
--- a/R/dsl_verbs.R
+++ b/R/dsl_verbs.R
@@ -358,6 +358,7 @@ temporal <- function(data_or_pipe, kind = NULL, ...) {
 #'
 #' @param data_or_pipe Data object or `lna_pipeline`.
 #' @param levels Optional number of HRBF resolution levels.
+#' @param num_extra_fine_levels Number of additional finest dyadic levels. Default: 0.
 #' @param ... Additional parameters for the HRBF transform.
 #'
 #' @return An `lna_pipeline` object with the HRBF step appended.

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ coeff <- hrbf_project_matrix(X, mask, params)
 reconstructed <- hrbf_reconstruct_matrix(coeff, mask, params)
 ```
 
+Set `num_extra_fine_levels` in the parameter list to add additional fine-scale levels beyond `levels`.
 ### Validation and Fork Safety
 
 `validate_lna()` uses cached compiled JSON schemas. When running validation inside forked workers (e.g., with `future::plan(multicore)`), clear this cache in each worker using `lna:::schema_cache_clear()` to avoid potential fork-safety issues.

--- a/inst/schemas/spat.hrbf.schema.json
+++ b/inst/schemas/spat.hrbf.schema.json
@@ -18,10 +18,10 @@
       "description": "Number of dyadic levels (0 to J)."
     },
     "num_extra_fine_levels": {
-      "type": "integer",
+        "type": "integer",
       "minimum": 0,
       "default": 0,
-      "description": "Additional dyadic levels beyond 'levels'. Functionality pending future implementation."
+      "description": "Additional dyadic levels beyond 'levels'. Extra centres are placed at finer scales."
     },
     "radius_factor": {
       "type": "number",

--- a/vignettes/hrbf.Rmd
+++ b/vignettes/hrbf.Rmd
@@ -24,6 +24,7 @@ without keeping the dense basis matrix:
 ```r
 write_lna(x, "analytic.h5", transforms = "spat.hrbf")
 ```
+Extra dyadic levels can be added with the `num_extra_fine_levels` parameter.
 
 Set `compute_atom_importance = TRUE` when writing to record per-atom
 importance metrics which can later be used to keep only the top


### PR DESCRIPTION
## Summary
- clarify description of `num_extra_fine_levels` in schema
- document `num_extra_fine_levels` parameter for `hrbf()` verb
- mention fine-scale parameter in README and HRBF vignette

## Testing
- `./run-tests.sh` *(fails: R is not installed)*