### PR TITLE
Document HRBF Rcpp option

### DIFF
--- a/LatentNeuroArchiveCodingGuide.md
+++ b/LatentNeuroArchiveCodingGuide.md
@@ -172,6 +172,7 @@ lna_options <- function(...) { # Uses internal package environment }
     *   `lna::scaffold_transform(type)`: Generates template files, including a stub using `lna:::default_params()`.
     *   `lna:::schema_cache_clear()`: Exposes cache clearing for tests.
 *   **Progress Reporting:** Check `!progressr::handlers_is_empty()` before invoking `progressr`.
+*   **Rcpp Acceleration Toggle:** HRBF-related helpers use C++ implementations when available.  This behaviour is controlled by `getOption("lna.hrbf.use_rcpp_helpers", TRUE)` (see `rcpp_control()`).  Setting it to `FALSE` forces the pure-R fallbacks.
 
 **8. Package Structure**
 

--- a/man/label_components.Rd
+++ b/man/label_components.Rd
@@ -16,6 +16,8 @@ A list with elements `count` (number of components) and `labels`
 \description{
 Provides a minimal 6-neighbourhood connected component labeller used by the
 HRBF helpers. When available and enabled, a faster Rcpp implementation is
-utilised. Otherwise a pure-R fallback is employed.
+utilised. The behaviour is controlled by the option
+\code{lna.hrbf.use_rcpp_helpers}; set it to \code{FALSE} to force the
+pure-R fallback.
 }
 \keyword{internal}

--- a/man/rcpp_control.Rd
+++ b/man/rcpp_control.Rd
@@ -22,6 +22,9 @@ Invisibly returns a list of current option values
 \description{
 Enable or disable Rcpp acceleration for neuroarchive functions.
 When disabled, pure R implementations are used as fallbacks.
+The HRBF helpers consult the option \code{lna.hrbf.use_rcpp_helpers}
+(default \code{TRUE}).  You can also adjust this option directly or via
+\code{rcpp_control()}.
 }
 \examples{
 \donttest{

--- a/raw-data/hrbf_proposal.md
+++ b/raw-data/hrbf_proposal.md
@@ -32,6 +32,7 @@ This appendix details the `spat.hrbf` transform, an analytic, descriptor-only sp
 *   **Multiresolution & Locality:** Inherently captures data at multiple spatial scales with localized basis functions.
 *   **Provable Coverage & Near-Orthogonality:** Poisson-disk sampling and whitening ensure good properties.
 *   **Fast Evaluation:** Generating atoms and projecting data involves `exp()` and sparse matrix operations; no iterative eigen-solvers.
+*   **Rcpp-Accelerated Helpers:** Core loops for Poisson-disk sampling, connected component labeling and OMP encoding are implemented in C++ via Rcpp.  These provide substantial speedups over the pure-R fallbacks.  Set `options(lna.hrbf.use_rcpp_helpers = FALSE)` to force the R implementations (useful for debugging or on systems without a C++ toolchain).
 *   **LNA Compatibility:** Fits the standard `basis`/`embed` contract.
 
 ### 3. LNA Implementation & Schemas

--- a/vignettes/hrbf.Rmd
+++ b/vignettes/hrbf.Rmd
@@ -72,3 +72,9 @@ write_lna(x, "transfer.h5",
 
 These tools allow sophisticated spatial representations while keeping
 files small and read/write operations fast.
+
+Core computations such as Poisson-disk sampling and sparse coding are
+implemented in C++ via Rcpp for performance. This acceleration is
+enabled by default but can be disabled with
+`options(lna.hrbf.use_rcpp_helpers = FALSE)` if a pure R fallback is
+needed.


### PR DESCRIPTION
## Summary
- mention Rcpp helpers and option in HRBF proposal
- document `lna.hrbf.use_rcpp_helpers` in coding guide
- add Rcpp note in HRBF vignette
- describe the option in `label_components` and `rcpp_control` man pages

## Testing
- `R -q -e 'sessionInfo()'` *(fails: command not found)*