### PR TITLE
Add default read path for LNAFacade

### DIFF
--- a/R/facade.R
+++ b/R/facade.R
@@ -47,9 +47,10 @@ LNAFacade <- R6::R6Class(
 
     #' @description
     #' Read data from an LNA file
-    #' @param file Path to an LNA file
+    #' @param file Path to an LNA file. If missing, uses \code{last_output}
+    #'   from the most recent call to \code{$write()}.
     #' @param ... Arguments forwarded to \code{read_lna()}
-    read = function(file, ...) {
+    read = function(file = self$last_output, ...) {
       read_lna(file = file, ...)
     }
   )

--- a/man/LNAFacade.Rd
+++ b/man/LNAFacade.Rd
@@ -85,13 +85,13 @@ Write data to an LNA file
 \subsection{Method \code{read()}}{
 Read data from an LNA file
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{LNAFacade$read(file, ...)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{LNAFacade$read(file = self$last_output, ...)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{file}}{Path to an LNA file}
+\item{\code{file}}{Path to an LNA file. Uses \code{last_output} from the most recent \code{$write()} if missing}
 
 \item{\code{...}}{Arguments forwarded to \code{read_lna()}}
 }

--- a/tests/testthat/test-facade.R
+++ b/tests/testthat/test-facade.R
@@ -12,3 +12,12 @@ test_that("LNAFacade writes and reads", {
   res <- fac$read(tmp)
   expect_true(inherits(res, "DataHandle"))
 })
+
+test_that("LNAFacade$read uses last_output when file missing", {
+  fac <- LNAFacade$new()
+  tmp <- local_tempfile(fileext = ".h5")
+  invisible(fac$write(array(2, dim = c(1,1,1)), tmp, transforms = character()))
+  expect_identical(fac$last_output, tmp)
+  res <- fac$read()
+  expect_true(inherits(res, "DataHandle"))
+})


### PR DESCRIPTION
## Summary
- make `LNAFacade$read()` default to the last written output
- document this new behaviour
- extend facade tests for the new default

## Testing
- `./run-tests.sh` *(fails: R is not installed)*