### PR TITLE
Add set_defaults method for LNAFacade

### DIFF
--- a/R/facade.R
+++ b/R/facade.R
@@ -27,6 +27,16 @@ LNAFacade <- R6::R6Class(
     },
 
     #' @description
+    #' Replace the default transform parameters
+    #' @param params Named list of default transform parameters
+    #' @return The \code{LNAFacade} object, invisibly
+    set_defaults = function(params) {
+      stopifnot(is.list(params))
+      self$default_transform_params <- params
+      invisible(self)
+    },
+
+    #' @description
     #' Write data to an LNA file
     #' @param x Array or list of arrays
     #' @param file Output path

--- a/man/LNAFacade.Rd
+++ b/man/LNAFacade.Rd
@@ -34,6 +34,7 @@ fac$read(tmp)
 \item \href{#method-LNAFacade-new}{\code{LNAFacade$new()}}
 \item \href{#method-LNAFacade-write}{\code{LNAFacade$write()}}
 \item \href{#method-LNAFacade-read}{\code{LNAFacade$read()}}
+\item \href{#method-LNAFacade-set_defaults}{\code{LNAFacade$set_defaults()}}
 \item \href{#method-LNAFacade-clone}{\code{LNAFacade$clone()}}
 }
 }
@@ -94,6 +95,23 @@ Read data from an LNA file
 \item{\code{file}}{Path to an LNA file}
 
 \item{\code{...}}{Arguments forwarded to \code{read_lna()}}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-LNAFacade-set_defaults"></a>}}
+\if{latex}{\out{\hypertarget{method-LNAFacade-set_defaults}{}}}
+\subsection{Method \code{set_defaults()}}{
+Replace the default transform parameters
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{LNAFacade$set_defaults(params)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{params}}{Named list of default transform parameters}
 }
 \if{html}{\out{</div>}}
 }

--- a/tests/testthat/test-facade.R
+++ b/tests/testthat/test-facade.R
@@ -12,3 +12,15 @@ test_that("LNAFacade writes and reads", {
   res <- fac$read(tmp)
   expect_true(inherits(res, "DataHandle"))
 })
+
+test_that("set_defaults replaces defaults for write", {
+  fac <- LNAFacade$new()
+  fac$set_defaults(list(quant = list(bits = 7L)))
+  tmp <- local_tempfile(fileext = ".h5")
+  fac$write(array(1, dim = c(1,1,1)), tmp, transforms = "quant")
+  h5 <- hdf5r::H5File$new(tmp, mode = "r")
+  dset <- h5[["/transforms/00_quant.json"]]
+  desc <- jsonlite::fromJSON(dset$read())
+  h5$close_all()
+  expect_equal(desc$params$bits, 7L)
+})


### PR DESCRIPTION
## Summary
- allow updating default transform parameters on `LNAFacade`
- document `set_defaults` in R docs and Rd file
- test that `set_defaults` affects subsequent `write()` calls

## Testing
- `./run-tests.sh` *(fails: R is not installed)*