### PR TITLE
Add quant_paths helper

### DIFF
--- a/R/transform_quant.R
+++ b/R/transform_quant.R
@@ -128,10 +128,11 @@ forward_step.quant <- function(type, desc, handle) {
   storage_type_str <- if (bits <= 8) "uint8" else "uint16"
 
   run_id <- handle$current_run_id %||% "run-01"
+  paths <- quant_paths(run_id)
   run_id <- sanitize_run_id(run_id)
-  data_path <- paste0("/scans/", run_id, "/quantized")
-  scale_path <- paste0("/scans/", run_id, "/quant_scale")
-  offset_path <- paste0("/scans/", run_id, "/quant_offset")
+  data_path <- paths$data
+  scale_path <- paths$scale
+  offset_path <- paths$offset
 
   blockwise <- identical(scope, "voxel") && !is.null(handle$h5) && handle$h5$is_valid
   if (blockwise) {
@@ -343,10 +344,11 @@ forward_step.quant <- function(type, desc, handle) {
 #' @keywords internal
 invert_step.quant <- function(type, desc, handle) {
   run_id <- handle$current_run_id %||% "run-01"
+  paths <- quant_paths(run_id)
   run_id <- sanitize_run_id(run_id)
-  data_path <- paste0("/scans/", run_id, "/quantized")
-  scale_path <- paste0("/scans/", run_id, "/quant_scale")
-  offset_path <- paste0("/scans/", run_id, "/quant_offset")
+  data_path <- paths$data
+  scale_path <- paths$scale
+  offset_path <- paths$offset
 
   root <- handle$h5[["/"]]
   dset <- NULL

--- a/R/utils_quant.R
+++ b/R/utils_quant.R
@@ -1,0 +1,16 @@
+#' Quant dataset paths helper
+#'
+#' Returns standard dataset paths for quantized data given a run ID.
+#'
+#' @param run_id Character run identifier.
+#' @return Named list with `data`, `scale`, and `offset` paths.
+#' @keywords internal
+quant_paths <- function(run_id) {
+  run_id <- sanitize_run_id(run_id)
+  list(
+    data = paste0("/scans/", run_id, "/quantized"),
+    scale = paste0("/scans/", run_id, "/quant_scale"),
+    offset = paste0("/scans/", run_id, "/quant_offset")
+  )
+}
+


### PR DESCRIPTION
## Summary
- add `quant_paths` helper for quantization dataset paths
- use `quant_paths` in forward and invert steps of the quant transform

## Testing
- `./run-tests.sh` *(fails: R is not installed)*