### PR TITLE
Implement HWT-S2-03 valid block storage

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,3 +12,6 @@
   `lna_get_quant_report()`.
 * Added `lna.debug.temporal` option. When `TRUE`, `forward_step.temporal` and
   `invert_step.temporal` emit debug messages; defaults to `FALSE` for quiet runs.
+* `forward_step.spat.haar_octwave` now stores a list of valid finest-level
+  block Morton codes at `/aux_meta/haar_octwave/valid_blocks_L-1` for
+  optimized ROI streaming.

--- a/inst/schemas/spat.haar_octwave.schema.json
+++ b/inst/schemas/spat.haar_octwave.schema.json
@@ -44,10 +44,10 @@
       "readOnly": true,
       "description": "SHA1 hash of Morton-ordered in-mask voxel indices for reproducibility."
     },
-    "num_coeffs_per_level": {
-      "type": "object",
-      "readOnly": true,
-      "properties": {
+      "num_coeffs_per_level": {
+        "type": "object",
+        "readOnly": true,
+        "properties": {
         "lowpass": {
           "type": "array",
           "items": { "type": "integer" },
@@ -61,6 +61,13 @@
       },
       "required": ["lowpass", "detail"],
       "description": "Actual number of coefficient vectors stored for each level and type."
+    },
+    "valid_finest_blocks_path": {
+      "type": "string",
+      "pattern": "^/aux_meta/.*",
+      "readOnly": true,
+      "default": null,
+      "description": "Optional HDF5 path storing uint32 Morton codes for finest-level 2x2x2 blocks with in-mask voxels."
     }
   },
   "required": ["levels"],

--- a/tests/testthat/test-forward_step_spat_haar_octwave.R
+++ b/tests/testthat/test-forward_step_spat_haar_octwave.R
@@ -49,6 +49,12 @@ test_that("forward_step.spat.haar_octwave basic IO", {
   expect_true(out$has_key("wavelet_coefficients"))
   stash_mat <- out$stash$wavelet_coefficients
   expect_equal(dim(stash_mat), c(2,9))
+
+  expect_equal(p$valid_finest_blocks_path,
+               "/aux_meta/haar_octwave/valid_blocks_L-1")
+  expect_true(p$valid_finest_blocks_path %in% out$plan$datasets$path)
+  expect_equal(out$plan$payloads[[p$valid_finest_blocks_path]],
+               neuroarchive:::get_valid_finest_blocks(mask))
 })
 
 test_that("forward_step.spat.haar_octwave sparsifies details", {


### PR DESCRIPTION
## Summary
- add helper to compute valid finest blocks
- store valid block list in `forward_step.spat.haar_octwave`
- extend schema with `valid_finest_blocks_path`
- test new dataset path and payload
- document feature in NEWS

## Testing
- `./run-tests.sh` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6839f543c5d8832dbd249f9474f6cf6c