### PR TITLE
Add documentation for Haar octwave transform

### DIFF
--- a/man/spat.haar_octwave.Rd
+++ b/man/spat.haar_octwave.Rd
@@ -1,0 +1,15 @@
+\name{spat.haar_octwave}
+\alias{spat.haar_octwave}
+\title{Mask-Adaptive Haar Wavelet Pyramid Transform}
+\description{
+The \code{spat.haar_octwave} transform applies a Haar lifting scheme on a Morton-ordered implicit octree. Only the root and per-level detail coefficients are stored, keeping the basis implicit while preserving perfect reconstruction before quantisation.
+}
+\section{Parameters}{
+\itemize{
+  \item{\code{levels}}{Number of decomposition levels.}
+  \item{\code{detail_threshold_type}}{Strategy for sparsifying detail coefficients.}
+  \item{\code{detail_threshold_value}}{Threshold used when sparsifying.}
+}}
+\details{
+A full description of the algorithm and layout is provided in \file{raw-data/Haar_Pyramind.md}. See also the vignette section \dQuote{Appendix: Mask-Adaptive Haar Octwave}.
+}

--- a/vignettes/cookbook.Rmd
+++ b/vignettes/cookbook.Rmd
@@ -134,3 +134,30 @@ validate_lna(spca_file)
 issues <- validate_lna(spca_file, strict = FALSE)
 print(issues)
 ```
+
+## Mask-Adaptive Haar Octwave Example
+
+```r
+# Haar wavelet compression with optional thresholding
+oct_file <- "octwave_example.h5"
+write_lna(
+  x,
+  oct_file,
+  transforms = "spat.haar_octwave",
+  transform_params = list(
+    `spat.haar_octwave` = list(
+      levels = 2,
+      detail_threshold_type = "absolute",
+      detail_threshold_value = 0.01
+    )
+  )
+)
+
+r <- read_lna(oct_file, lazy = TRUE)
+r$subset(time_idx = 1)
+data_reco <- r$data()
+r$close()
+```
+
+The `levels` parameter sets the depth of the octree. Small detail coefficients can be removed by adjusting `detail_threshold_type` and `detail_threshold_value`.
+

--- a/vignettes/hrbf.Rmd
+++ b/vignettes/hrbf.Rmd
@@ -78,3 +78,7 @@ implemented in C++ via Rcpp for performance. This acceleration is
 enabled by default but can be disabled with
 `options(lna.hrbf.use_rcpp_helpers = FALSE)` if a pure R fallback is
 needed.
+
+## Appendix: Mask-Adaptive Haar Octwave
+
+The `spat.haar_octwave` transform performs a Haar lifting wavelet analysis on a Morton-ordered octree derived from the voxel mask. Only root and detail coefficient datasets are stored. The `levels` parameter controls the octree depth, and small detail coefficients can be removed by specifying `detail_threshold_type` and `detail_threshold_value`. See `?spat.haar_octwave` for further reference.


### PR DESCRIPTION
## Summary
- document the `spat.haar_octwave` transform
- add appendix section in HRBF vignette
- add Haar octwave example to the cookbook vignette

## Testing
- `./run-tests.sh` *(fails: R is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683a041ecb68832da853cdae793cdcbe