### PR TITLE
Add multi-level Haar lifting roundtrip test

### DIFF
--- a/tests/testthat/test-haar_octwave_multilevel.R
+++ b/tests/testthat/test-haar_octwave_multilevel.R
@@ -1,0 +1,15 @@
+library(testthat)
+
+# Multi-level forward/inverse Haar lifting should reconstruct the input
+
+test_that("multi-level Haar lifting roundtrip reconstructs X", {
+  mask <- make_ball_mask(radius = 1L)
+  arr  <- make_synthetic_fmri(time = 4L, mask = mask)
+  X    <- t(neuroarchive:::convert_to_masked_vox_time_matrix(arr, mask))
+  opts <- options(lna.hwt.use_rcpp = FALSE)
+  coeff <- neuroarchive:::perform_haar_lift_analysis(X, mask, levels = 2)
+  reco  <- neuroarchive:::perform_haar_lift_synthesis(coeff, mask, levels = 2)
+  options(opts)
+  expect_equal(reco, X, tolerance = 1e-6)
+})
+


### PR DESCRIPTION
## Summary
- add a regression test for multi-level Haar lifting analysis/synthesis

## Testing
- `./run-tests.sh` *(fails: R is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683a109ba7f0832d9d51110747d4ea21