### PR TITLE
Use shared allow_plugins normalisation

### DIFF
--- a/R/reader.R
+++ b/R/reader.R
@@ -160,10 +160,7 @@ lna_reader <- R6::R6Class("lna_reader",
       )
       tf_group <- h5[["transforms"]]
       transforms <- discover_transforms(tf_group)
-      allow_plugins <- self$allow_plugins
-      if (identical(allow_plugins, "prompt") && !rlang::is_interactive()) {
-        allow_plugins <- "installed"
-      }
+      allow_plugins <- normalize_allow_plugins(self$allow_plugins)
       if (nrow(transforms) > 0) {
         missing_methods <- transforms$type[
           vapply(


### PR DESCRIPTION
## Summary
- refactor lna_reader$data() to reuse normalize_allow_plugins

## Testing
- `./run-tests.sh` *(fails: R is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683a23b664a0832da28aa64beb8b40a2