### PR TITLE
Add safe HDF5 closing helper

### DIFF
--- a/R/transform_basis_empirical_hrbf_compressed.R
+++ b/R/transform_basis_empirical_hrbf_compressed.R
@@ -46,7 +46,7 @@ invert_step.basis.empirical_hrbf_compressed <- function(type, desc, handle) {
     if (gpath == "") gpath <- "/"
     tf_group <- root[[gpath]]
     dict_desc <- read_json_descriptor(tf_group, dname)
-    if (inherits(tf_group, "H5Group")) tf_group$close()
+    safe_h5_close(tf_group)
     
     mask_neurovol <- handle$mask_info$mask
     if (is.null(mask_neurovol)) {

--- a/R/transform_embed_transfer_hrbf_basis.R
+++ b/R/transform_embed_transfer_hrbf_basis.R
@@ -116,7 +116,7 @@ invert_step.embed.transfer_hrbf_basis <- function(type, desc, handle) {
   on.exit(h5$close_all(), add = TRUE)
   tf_group <- h5[["/transforms"]]
   desc <- read_json_descriptor(tf_group, desc_name)
-  if (inherits(tf_group, "H5Group")) tf_group$close()
+  safe_h5_close(tf_group)
 
   if (!identical(desc$type, "basis.empirical_hrbf_compressed")) {
     abort_lna("Source descriptor must be of type 'basis.empirical_hrbf_compressed'",

--- a/R/transform_quant.R
+++ b/R/transform_quant.R
@@ -367,7 +367,7 @@ invert_step.quant <- function(type, desc, handle) {
     stop(paste0("Error reading dataset '", data_path, "': ",
                 conditionMessage(e)), call. = FALSE)
   }, finally = {
-    if (!is.null(dset) && inherits(dset, "H5D")) dset$close()
+    safe_h5_close(dset)
   })
   if (!is.null(desc$params$bits) && !is.na(desc$params$bits)) {
     if (!is.na(attr_bits) && attr_bits != desc$params$bits) {

--- a/R/utils_core_read.R
+++ b/R/utils_core_read.R
@@ -165,7 +165,7 @@ process_run_core_read <- function(rid, h5, runs, subset_params, transforms,
     handle <- apply_invert_transforms(handle, transforms, tf_group, validate, h5)
   } else {
     root <- h5[["/"]]
-    on.exit(if (inherits(root, "H5Group")) root$close(), add = TRUE)
+      on.exit(safe_h5_close(root), add = TRUE)
     path <- file.path("scans", rid, "data", "values")
     data <- h5_read(root, path)
     handle <- handle$with(stash = list(input = data))

--- a/R/utils_json.R
+++ b/R/utils_json.R
@@ -109,7 +109,7 @@ write_json_descriptor <- function(h5_group, name, desc_list) {
     # Close resources if they were successfully created
     if (!is.null(str_type) && inherits(str_type, "H5T")) str_type$close()
     if (!is.null(space) && inherits(space, "H5S")) space$close()
-    if (!is.null(dset) && inherits(dset, "H5D")) dset$close()
+      safe_h5_close(dset)
   }, add = TRUE)
 
   # --- Define scalar, variable-length, UTF-8 string dataset ----

--- a/R/utils_reports.R
+++ b/R/utils_reports.R
@@ -54,7 +54,7 @@ lna_get_transform_report <- function(lna_file, transform_index_or_name) {
   assert_h5_path(root, report_path)
 
   dset <- root[[report_path]]
-  on.exit(if (!is.null(dset) && inherits(dset, "H5D")) dset$close(), add = TRUE)
+  on.exit(safe_h5_close(dset), add = TRUE)
   
   # When the HDF5 datatype is H5T_STD_U8LE (unsigned 8-bit int),
   # dset$read() returns a numeric vector of byte values.

--- a/R/validate.R
+++ b/R/validate.R
@@ -170,7 +170,7 @@ validate_lna <- function(file, strict = TRUE, checksum = TRUE) {
             }
 
             dset <- h5[[path]]
-            on.exit(if (inherits(dset, "H5D")) dset$close(), add = TRUE)
+            on.exit(safe_h5_close(dset), add = TRUE)
             if (!is.null(ds$dims)) {
               if (!identical(as.integer(ds$dims), as.integer(dset$dims))) {
                 fail(sprintf("Dimensions mismatch for dataset '%s'", path))


### PR DESCRIPTION
## Summary
- add a `safe_h5_close()` helper that quietly closes HDF5 datasets, groups, or files
- use `safe_h5_close()` in various modules instead of manual checks

## Testing
- `./run-tests.sh` *(fails: R is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683a23aec1b4832d85b5336c8e667480