### PR TITLE
Add tests for run id utilities and empty array dataset handling

### DIFF
--- a/tests/testthat/test-h5_write_empty_array.R
+++ b/tests/testthat/test-h5_write_empty_array.R
@@ -1,0 +1,23 @@
+library(testthat)
+library(hdf5r)
+
+# Test writing and reading an empty array using placeholder logic
+
+test_that("h5_write_dataset preserves empty array via placeholder", {
+  tmp <- local_tempfile(fileext = ".h5")
+  h5 <- H5File$new(tmp, mode = "w")
+  root <- h5[["/"]]
+
+  arr <- array(numeric(0), dim = c(0, 3, 2))
+  neuroarchive:::h5_write_dataset(root, "empty/data", arr)
+
+  dset <- root[["empty/data"]]
+  expect_true(neuroarchive:::h5_attr_exists(dset, "lna_empty_array_placeholder"))
+
+  read_back <- neuroarchive:::h5_read(root, "empty/data")
+  expect_equal(dim(read_back), dim(arr))
+  expect_equal(length(read_back), 0)
+
+  dset$close()
+  h5$close_all()
+})

--- a/tests/testthat/test-run_id_utils.R
+++ b/tests/testthat/test-run_id_utils.R
@@ -1,0 +1,25 @@
+library(testthat)
+library(hdf5r)
+
+# Tests for discover_run_ids and resolve_run_ids
+
+test_that("discover_run_ids returns sorted run identifiers", {
+  tmp <- local_tempfile(fileext = ".h5")
+  h5 <- H5File$new(tmp, mode = "w")
+  scans <- h5$create_group("scans")
+  scans$create_group("run-03")
+  scans$create_group("run-01")
+  scans$create_group("run-02")
+  scans$create_group("misc")
+
+  runs <- neuroarchive:::discover_run_ids(h5)
+  expect_equal(runs, c("run-01", "run-02", "run-03"))
+  h5$close_all()
+})
+
+test_that("resolve_run_ids matches names and globs uniquely", {
+  available <- c("run-01", "run-02", "run-03")
+  patterns <- c("run-*", "run-02")
+  res <- neuroarchive:::resolve_run_ids(patterns, available)
+  expect_equal(res, c("run-01", "run-02", "run-03"))
+})


### PR DESCRIPTION
## Summary
- add tests for `discover_run_ids` and `resolve_run_ids`
- test `h5_write_dataset` with empty array placeholder logic

## Testing
- `./run-tests.sh` *(fails: R is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6846e5e680e8832db877d0460c434240